### PR TITLE
Pyfilesystem dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,9 @@ install:
 # pytest datafs --cov=datafs --cov-report term-missing;
 script: 
   - if [[ "$TRAVIS_PYTHON_VERSION" == "3.5" ]]; then
-      py.test;
+      pytest datafs tests docs examples;
     else
-      py.test --cov=datafs --doctest-modules --cov-report term-missing;
+      pytest datafs tests docs examples --cov --doctest-modules --cov-report term-missing;
     fi
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ language: python
 python:
   - "2.7"
   - "3.3"
-  - "3.4"
-  - "3.5"
+  # - "3.4"
+  # - "3.5"
   # PyPy versions
   - "pypy"
   - "pypy"  # PyPy2 2.5.0
@@ -28,7 +28,7 @@ script:
   - if [[ "$TRAVIS_PYTHON_VERSION" == "3.5" ]]; then
       py.test;
     else
-      py.test --cov=datafs --cov-report term-missing;
+      py.test --cov=datafs --doctest-modules --cov-report term-missing;
     fi
 
 

--- a/datafs/__init__.py
+++ b/datafs/__init__.py
@@ -4,10 +4,10 @@
 '''
 
 from __future__ import absolute_import
+from datafs.core.data_api import DataAPI
 
 __author__ = """Climate Impact Lab"""
 __email__ = 'jsimcock@rhg.com'
 __version__ = '0.2.2'
 
-
-from datafs.core.data_api import DataAPI
+__all__ = [DataAPI]

--- a/datafs/core/data_api.py
+++ b/datafs/core/data_api.py
@@ -11,6 +11,7 @@ import os
 import time
 import hashlib
 
+
 class DataAPI(object):
 
     TimestampFormat = '%Y%m%d-%H%M%S'
@@ -32,7 +33,7 @@ class DataAPI(object):
     def attach_cache(self, service):
         self._cache = CachingService(service)
         self._cache.api = self
-    
+
     @property
     def manager(self):
         return self._manager
@@ -48,13 +49,14 @@ class DataAPI(object):
             return self.DefaultAuthorityName
 
         if len(self._authorities) == 0:
-            raise ValueError('No authorities have been attached. Use DataApi.attach_authority to attach a data service.')
+            raise ValueError(
+                'No authorities have been attached. Use DataApi.attach_authority to attach a data service.')
 
         if len(self._authorities) > 1:
-            raise ValueError('Default authority ambiguous. Specify an authority or set the DefaultAuthorityName attribute.')
+            raise ValueError(
+                'Default authority ambiguous. Specify an authority or set the DefaultAuthorityName attribute.')
 
         return list(self._authorities.keys())[0]
-
 
     @property
     def default_authority(self):
@@ -64,14 +66,25 @@ class DataAPI(object):
         self._manager = manager
         self.manager.api = self
 
-    def create_archive(self, archive_name, authority_name=None, service_path=None, raise_if_exists=True, **metadata):
+    def create_archive(
+            self,
+            archive_name,
+            authority_name=None,
+            service_path=None,
+            raise_if_exists=True,
+            **metadata):
         if authority_name is None:
             authority_name = self.default_authority_name
 
         if service_path is None:
             service_path = self.create_service_path(archive_name)
 
-        self.manager.create_archive(archive_name, authority_name, service_path=service_path, raise_if_exists=raise_if_exists, **metadata)
+        self.manager.create_archive(
+            archive_name,
+            authority_name,
+            service_path=service_path,
+            raise_if_exists=raise_if_exists,
+            **metadata)
 
     def get_archive(self, archive_name):
         return self.manager.get_archive(archive_name)
@@ -120,9 +133,9 @@ class DataAPI(object):
         Overloading
         -----------
 
-        Overload this function to change default internal service path format 
+        Overload this function to change default internal service path format
         and to enforce certain requirements on paths:
-    
+
         .. code-block:: python
 
             >>> class MyAPI(DataAPI):
@@ -131,7 +144,7 @@ class DataAPI(object):
             ...         if '_' in archive_name:
             ...             raise ValueError('No underscores allowed!')
             ...         return archive_name
-            ... 
+            ...
             >>> api = MyAPI
             >>> api.create_service_path('pictures_2016_may_vegas_wedding.png')   # doctest: +ELLIPSIS
             Traceback (most recent call last):
@@ -143,14 +156,13 @@ class DataAPI(object):
 
         return fs.path.join(*tuple(archive_name.split('_')))
 
-
     @staticmethod
     def hash_file(filepath):
         '''
         Utility function for hashing file contents
 
         Overload this function to change the file equality checking algorithm
-    
+
         Parameters
 
 
@@ -167,6 +179,4 @@ class DataAPI(object):
             with open(filepath, 'rb') as f:
                 hashval = hashlib.md5(f.read())
 
-
         return 'md5', hashval.hexdigest()
-

--- a/datafs/core/data_api.py
+++ b/datafs/core/data_api.py
@@ -53,7 +53,7 @@ class DataAPI(object):
         if len(self._authorities) > 1:
             raise ValueError('Default authority ambiguous. Specify an authority or set the DefaultAuthorityName attribute.')
 
-        return self._authorities.keys()[0]
+        return list(self._authorities.keys())[0]
 
 
     @property

--- a/datafs/core/data_api.py
+++ b/datafs/core/data_api.py
@@ -70,14 +70,14 @@ class DataAPI(object):
         if service_path is None:
             service_path = self.create_service_path(archive_name)
 
-        self.manager.create_archive(archive_name, authority_name, service_path=None, raise_if_exists=raise_if_exists, **metadata)
+        self.manager.create_archive(archive_name, authority_name, service_path=service_path, raise_if_exists=raise_if_exists, **metadata)
 
     def get_archive(self, archive_name):
         return self.manager.get_archive(archive_name)
 
     @property
     def archives(self):
-        self.manager.get_archives()
+        return self.manager.get_archives()
 
     @classmethod
     def create_timestamp(cls):

--- a/datafs/core/data_api.py
+++ b/datafs/core/data_api.py
@@ -1,10 +1,7 @@
 from __future__ import absolute_import
 
-from datafs.managers.manager import BaseDataManager
 from datafs.services.service import DataService, CachingService
 
-from fs.multifs import MultiFS
-from collections import OrderedDict
 import fs.path
 
 import os
@@ -50,11 +47,11 @@ class DataAPI(object):
 
         if len(self._authorities) == 0:
             raise ValueError(
-                'No authorities have been attached. Use DataApi.attach_authority to attach a data service.')
+                'No authorities found. See attach_authority.')
 
         if len(self._authorities) > 1:
             raise ValueError(
-                'Default authority ambiguous. Specify an authority or set the DefaultAuthorityName attribute.')
+                'Authority ambiguous. Set authority or DefaultAuthorityName.')
 
         return list(self._authorities.keys())[0]
 
@@ -127,7 +124,8 @@ class DataAPI(object):
 
         .. code-block:: python
 
-            >>> print(DataAPI.create_service_path('pictures_2016_may_vegas_wedding.png'))
+            >>> print(DataAPI.create_service_path(
+            ...     'pictures_2016_may_vegas_wedding.png'))
             pictures/2016/may/vegas/wedding.png
 
         Overloading
@@ -146,7 +144,8 @@ class DataAPI(object):
             ...         return archive_name
             ...
             >>> api = MyAPI
-            >>> api.create_service_path('pictures_2016_may_vegas_wedding.png')   # doctest: +ELLIPSIS
+            >>> api.create_service_path(
+            ...   'pictures_2016_may_vegas_wedding.png')   # doctest: +ELLIPSIS
             Traceback (most recent call last):
             ...
             ValueError: No underscores allowed!

--- a/datafs/core/data_api.py
+++ b/datafs/core/data_api.py
@@ -1,47 +1,76 @@
 from __future__ import absolute_import
 
 from datafs.managers.manager import BaseDataManager
-from datafs.services.service import DataService
+from datafs.services.service import DataService, CachingService
 
 from fs.multifs import MultiFS
 import fs.path
 
-import time, hashlib
+import os
+import time
+import hashlib
 
 class DataAPI(object):
 
-    DatabaseName = 'MyDatabase'
-    DataTableName = 'DataFiles'
-
     TimestampFormat = '%Y%m%d-%H%M%S'
+
+    DefaultAuthorityName = None
 
     def __init__(self, username, contact):
         self.username = username
         self.contact = contact
 
-        self.manager = None
-        self.authorities = {}
-        self.cache = None
+        self._manager = None
+        self._cache = None
+        self._authorities = {}
 
     def attach_authority(self, service_name, service):
-        self.authorities[service_name] = DataService(service)
-        self.authorities[service_name].api = self
+        self._authorities[service_name] = DataService(service)
+        self._authorities[service_name].api = self
 
-    # @property
-    # def download_service(self):
-    #     _download_service = MultiFS()
+    def attach_cache(self, service):
+        self._cache = CachingService(service)
+        self._cache.api = self
+    
+    @property
+    def manager(self):
+        return self._manager
 
-    #     for service_name in reversed(list(self.download_priority)):
-    #         _download_service.addfs(service_name, self.authorities[service_name].fs)
+    @property
+    def cache(self):
+        return self._cache
 
-    #     return DataService(_download_service)
+    @property
+    def default_authority_name(self):
+
+        if self.DefaultAuthorityName is not None:
+            return self.DefaultAuthorityName
+
+        if len(self._authorities) == 0:
+            raise ValueError('No authorities have been attached. Use DataApi.attach_authority to attach a data service.')
+
+        if len(self._authorities) > 1:
+            raise ValueError('Default authority ambiguous. Specify an authority or set the DefaultAuthorityName attribute.')
+
+        return self._authorities.keys()[0]
+
+
+    @property
+    def default_authority(self):
+        return self._authorities[self.default_authority_name]
 
     def attach_manager(self, manager):
-        self.manager = manager
+        self._manager = manager
         self.manager.api = self
 
-    def create_archive(self, archive_name, raise_if_exists=True, **metadata):
-        self.manager.create_archive(archive_name, raise_if_exists=raise_if_exists, **metadata)
+    def create_archive(self, archive_name, authority_name=None, service_path=None, raise_if_exists=True, **metadata):
+        if authority_name is None:
+            authority_name = self.default_authority_name
+
+        if service_path is None:
+            service_path = self.create_service_path(archive_name)
+
+        self.manager.create_archive(archive_name, authority_name, service_path=None, raise_if_exists=raise_if_exists, **metadata)
 
     def get_archive(self, archive_name):
         return self.manager.get_archive(archive_name)
@@ -61,14 +90,58 @@ class DataAPI(object):
         return time.strftime(cls.TimestampFormat, time.gmtime())
 
     @classmethod
-    def create_service_path(cls, filepath, archive_name):
+    def create_service_path(cls, archive_name):
         '''
-        Utility function for creating internal service paths
+        Utility function for creating and checking internal service paths
 
-        Overload this function to change internal service path format
+        Parameters
+        ----------
+
+        archive_name : str
+            Name of the archive from which to create a service path
+
+        Returns
+        -------
+
+        service_path : str
+            Internal path used by services to reference archive data
+
+        Default: split archive name on underscores
+
+        Example
+        -------
+
+        .. code-block:: python
+
+            >>> print(DataAPI.create_service_path('pictures_2016_may_vegas_wedding.png'))
+            pictures/2016/may/vegas/wedding.png
+
+        Overloading
+        -----------
+
+        Overload this function to change default internal service path format 
+        and to enforce certain requirements on paths:
+    
+        .. code-block:: python
+
+            >>> class MyAPI(DataAPI):
+            ...     @classmethod
+            ...     def create_service_path(cls, archive_name):
+            ...         if '_' in archive_name:
+            ...             raise ValueError('No underscores allowed!')
+            ...         return archive_name
+            ... 
+            >>> api = MyAPI
+            >>> api.create_service_path('pictures_2016_may_vegas_wedding.png')   # doctest: +ELLIPSIS
+            Traceback (most recent call last):
+            ...
+            ValueError: No underscores allowed!
+
+
         '''
 
-        return fs.path.join(*tuple(archive_name.split('.')))
+        return fs.path.join(*tuple(archive_name.split('_')))
+
 
     @staticmethod
     def hash_file(filepath):
@@ -89,8 +162,10 @@ class DataAPI(object):
             Hash digest value
         '''
 
-        with open(filepath, 'rb') as f:
-            hashval = hashlib.md5(f.read())
+        if os.path.isfile(filepath):
+            with open(filepath, 'rb') as f:
+                hashval = hashlib.md5(f.read())
+
 
         return 'md5', hashval.hexdigest()
 

--- a/datafs/core/data_api.py
+++ b/datafs/core/data_api.py
@@ -50,10 +50,6 @@ class DataAPI(object):
     def archives(self):
         self.manager.get_archives()
 
-    @archives.setter
-    def archives(self):
-        raise AttributeError('archives attribute cannot be set')
-
     @classmethod
     def create_timestamp(cls):
         '''

--- a/datafs/core/data_archive.py
+++ b/datafs/core/data_archive.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from datafs.core.data_file import DataFile
+from datafs.core.data_file import DataFile, LocalFile
 
 
 class DataArchive(object):
@@ -62,11 +62,6 @@ class DataArchive(object):
             return
 
         checksum = {"algorithm": algorithm, "value": hashval}
-
-        # loop through upload services
-        #   and put file to each
-
-        services = []
 
         self.authority.upload(filepath, self.service_path)
 

--- a/datafs/core/data_archive.py
+++ b/datafs/core/data_archive.py
@@ -99,7 +99,7 @@ class DataArchive(object):
         Opens a file for read/write
         '''
 
-        return DataFile
+        return lambda *args, **kwargs: DataFile(self, *args, **kwargs)
 
     @property
     def get_local_path(self):
@@ -107,7 +107,7 @@ class DataArchive(object):
         Returns a local path for read/write
         '''
 
-        return LocalFile
+        return lambda *args, **kwargs: LocalFile(self, *args, **kwargs)
 
 
     def isfile(self, *args, **kwargs):

--- a/datafs/core/data_archive.py
+++ b/datafs/core/data_archive.py
@@ -1,18 +1,19 @@
 
 
 class DataArchive(object):
-    def __init__(self, api, archive_name):
+    def __init__(self, api, archive_name, authority):
        self.api = api
        self.archive_name = archive_name
 
+       self._authority_name = authority
+
+    @property
+    def authority(self):
+        return self.api.authorities[self._authority_name]
 
     @property
     def latest(self):
         return self.get_version(sorted(self.version_ids)[-1])
-
-    @latest.setter
-    def latest(self, value):
-        raise AttributeError('latest attribute cannot be set')
 
 
     @property
@@ -24,21 +25,12 @@ class DataArchive(object):
         return self.api.manager.get_all_version_ids(self.archive_name)
 
 
-    @version_ids.setter
-    def version_ids(self, value):
-        raise AttributeError('version_ids attribute cannot be set')
-
-
     @property
     def versions(self):
         '''
         File history for an archive
         '''
         return [self.get_version(v) for v in self.version_ids]
-
-    @versions.setter
-    def versions(self, value):
-        raise AttributeError('versions attribute cannot be set')
 
     
     @property

--- a/datafs/core/data_archive.py
+++ b/datafs/core/data_archive.py
@@ -4,12 +4,13 @@ from datafs.core.data_file import DataFile
 
 
 class DataArchive(object):
-    def __init__(self, api, archive_name, authority, service_path):
-       self.api = api
-       self.archive_name = archive_name
 
-       self._authority_name = authority
-       self._service_path = service_path
+    def __init__(self, api, archive_name, authority, service_path):
+        self.api = api
+        self.archive_name = archive_name
+
+        self._authority_name = authority
+        self._service_path = service_path
 
     @property
     def authority_name(self):
@@ -22,7 +23,7 @@ class DataArchive(object):
     @property
     def service_path(self):
         return self._service_path
-    
+
     @property
     def metadata(self):
         return self.api.manager.get_metadata(self.archive_name)
@@ -30,7 +31,6 @@ class DataArchive(object):
     @property
     def latest_hash(self):
         pass
-
 
     def update(self, filepath, cache=False, **kwargs):
         '''
@@ -46,7 +46,7 @@ class DataArchive(object):
             Save file to cache before upload (default False)
 
         **kwargs stored as update to metadata.
-        
+
 
         .. todo::
 
@@ -61,9 +61,7 @@ class DataArchive(object):
             self.update_metadata(kwargs)
             return
 
-
         checksum = {"algorithm": algorithm, "value": hashval}
-
 
         # loop through upload services
         #   and put file to each
@@ -74,22 +72,18 @@ class DataArchive(object):
 
         if cache and self.api.cache:
             self.api.cache.upload(filepath, self.service_path)
-        
 
         # update records in self.api.manager
         self.api.manager.update(
-            archive_name = self.archive_name, 
-            checksum = checksum,
-            metadata = kwargs)
-
+            archive_name=self.archive_name,
+            checksum=checksum,
+            metadata=kwargs)
 
     def update_metadata(self, **kwargs):
-        
+
         # just update records in self.api.manager
-        
+
         self.api.manager.update(self.archive_name, kwargs)
-
-
 
     # File I/O methods
 
@@ -109,20 +103,17 @@ class DataArchive(object):
 
         return lambda *args, **kwargs: LocalFile(self, *args, **kwargs)
 
-
     def isfile(self, *args, **kwargs):
         '''
         Check whether the path exists and is a file
         '''
         self.fs.isfile(self.path, *args, **kwargs)
 
-
     def getinfo(self, *args, **kwargs):
         '''
         Return information about the path e.g. size, mtime
         '''
         self.fs.getinfo(self.path, *args, **kwargs)
-
 
     def desc(self, *args, **kwargs):
         '''
@@ -131,7 +122,6 @@ class DataArchive(object):
 
         self.fs.desc(self.path, *args, **kwargs)
 
-
     def exists(self, *args, **kwargs):
         '''
         Check whether a path exists as file or directory
@@ -139,14 +129,12 @@ class DataArchive(object):
 
         self.fs.exists(self.path, *args, **kwargs)
 
-
     def getmeta(self, *args, **kwargs):
         '''
         Get the value of a filesystem meta value, if it exists
         '''
 
         self.fs.getmeta(self.path, *args, **kwargs)
-
 
     def hasmeta(self, *args, **kwargs):
         '''

--- a/datafs/core/data_archive.py
+++ b/datafs/core/data_archive.py
@@ -1,62 +1,38 @@
+from __future__ import absolute_import
+
+from datafs.core.data_file import DataFile
 
 
 class DataArchive(object):
-    def __init__(self, api, archive_name, authority):
+    def __init__(self, api, archive_name, authority, service_path):
        self.api = api
        self.archive_name = archive_name
 
        self._authority_name = authority
+       self._service_path = service_path
+
+    @property
+    def authority_name(self):
+        return self._authority_name
 
     @property
     def authority(self):
-        return self.api.authorities[self._authority_name]
+        return self.api._authorities[self.authority_name]
 
     @property
-    def latest(self):
-        return self.get_version(sorted(self.version_ids)[-1])
-
-
-    @property
-    def version_ids(self):
-        '''
-        Version ID history for an archive
-        '''
-
-        return self.api.manager.get_all_version_ids(self.archive_name)
-
-
-    @property
-    def versions(self):
-        '''
-        File history for an archive
-        '''
-        return [self.get_version(v) for v in self.version_ids]
-
+    def service_path(self):
+        return self._service_path
     
     @property
     def metadata(self):
         return self.api.manager.get_metadata(self.archive_name)
 
-
-    def get_version(self, version_id):
-        '''
-        Returns a DataFile for a specified version_id
-
-        Parameters
-        ----------
-        version_id : str
-
-        Returns
-        -------
-        version : object
-            :py:class:`~datafs.core.DataFile` object
-
-        '''
-
-        return self.api.manager.get_version(self.archive_name, version_id)
+    @property
+    def latest_hash(self):
+        pass
 
 
-    def update(self, filepath, **kwargs):
+    def update(self, filepath, cache=False, **kwargs):
         '''
         Enter a new version to a DataArchive
 
@@ -66,6 +42,11 @@ class DataArchive(object):
         filepath : str
             The path to the file on your local file system
 
+        cache : bool
+            Save file to cache before upload (default False)
+
+        **kwargs stored as update to metadata.
+        
 
         .. todo::
 
@@ -75,41 +56,101 @@ class DataArchive(object):
         # Get hash value for file
 
         algorithm, hashval = self.api.hash_file(filepath)
-        hashsummary = {"algorithm": algorithm, "value": hashval}
+
+        if hashval == self.latest_hash:
+            self.update_metadata(kwargs)
+            return
 
 
-        # TODO: check for archive/version/hashval with manager
-        #       Not sure what the best way to implement this is
-        # services_with_hashval = self.api.manager.search_by_hashval() ??
+        checksum = {"algorithm": algorithm, "value": hashval}
 
 
         # loop through upload services
         #   and put file to each
 
-        version_id = self.api.create_version_id(self.archive_name, filepath)
-
         services = []
 
-        service_path = self.api.create_service_path(filepath, self.archive_name, version_id)
+        self.authority.upload(filepath, self.service_path)
 
-        for service_name in self.api.upload_services:
-            
-            service = self.api.services[service_name]
-            
-            service.upload(filepath, service_path)
-            services.append(service_name)
+        if cache and self.api.cache:
+            self.api.cache.upload(filepath, self.service_path)
+        
 
         # update records in self.api.manager
         self.api.manager.update(
             archive_name = self.archive_name, 
-            version_id = version_id, 
-            service_path = service_path,
-            service_data = services, 
-            checksum = hashsummary)
+            checksum = checksum,
+            metadata = kwargs)
 
 
     def update_metadata(self, **kwargs):
         
         # just update records in self.api.manager
         
-        self.api.manager.update(self.archive_name, **kwargs)
+        self.api.manager.update(self.archive_name, kwargs)
+
+
+
+    # File I/O methods
+
+    @property
+    def open(self):
+        '''
+        Opens a file for read/write
+        '''
+
+        return DataFile
+
+    @property
+    def get_local_path(self):
+        '''
+        Returns a local path for read/write
+        '''
+
+        return LocalFile
+
+
+    def isfile(self, *args, **kwargs):
+        '''
+        Check whether the path exists and is a file
+        '''
+        self.fs.isfile(self.path, *args, **kwargs)
+
+
+    def getinfo(self, *args, **kwargs):
+        '''
+        Return information about the path e.g. size, mtime
+        '''
+        self.fs.getinfo(self.path, *args, **kwargs)
+
+
+    def desc(self, *args, **kwargs):
+        '''
+        Return a short descriptive text regarding a path
+        '''
+
+        self.fs.desc(self.path, *args, **kwargs)
+
+
+    def exists(self, *args, **kwargs):
+        '''
+        Check whether a path exists as file or directory
+        '''
+
+        self.fs.exists(self.path, *args, **kwargs)
+
+
+    def getmeta(self, *args, **kwargs):
+        '''
+        Get the value of a filesystem meta value, if it exists
+        '''
+
+        self.fs.getmeta(self.path, *args, **kwargs)
+
+
+    def hasmeta(self, *args, **kwargs):
+        '''
+        Check if a filesystem meta value exists
+        '''
+
+        self.fs.hasmeta(self.path, *args, **kwargs)

--- a/datafs/core/data_file.py
+++ b/datafs/core/data_file.py
@@ -1,158 +1,91 @@
 
+import fs.utils
+import tempfile
+from fs.tempfs import TempFS
+from fs.multifs import MultiFS
 
-class DataFile(object):
-    '''
-    Base class for DataFile objects
-
-    '''
-
-
-    def __init__(self, api, archive, version_id, fs, path):
-        self.api = api
+class BaseVersionedFile(object):
+    def __init__(self, archive, cache=False, *args, **kwargs):
         self.archive = archive
-        self.version_id = version_id
-        self.fs = fs
-        self.path = path
+        self.cache = cache
 
-    @property
-    def metadata(self):
-        return self.archive.metadata
-
-    @metadata.setter
-    def metadata(self, value):
-        raise AttributeError('metadata attribute cannot be set')
-
-    def open(self, *args, **kwargs):
-        '''
-        Opens a file for read/writing
-        '''
-
-        return self.fs.open(self.path, *args, **kwargs)
+        self.args = args
+        self.kwargs = kwargs
 
 
-    def isfile(self, *args, **kwargs):
-        '''
-        Check whether the path exists and is a file
-        '''
-        self.fs.isfile(self.path, *args, **kwargs)
+    def _get_file_wrapper(self):
+
+        # Check the hash (if one exists) for a local version of the file
+        if self.archive.api.cache:
+
+            # Delete the file in the local cache if it is out of date.
+            local_hash = self.archive.api.cache.get_hash(self.archive.service_path)
+            latest_hash = self.archive.latest_hash()
+            if local_hash != latest_hash:
+                self.archive.api.cache.fs.remove(self.archive.service_path)
+
+        # Create a read-only wrapper with download priority cache, then authority
+        self.fs_wrapper = MultiFS()
+        self.fs_wrapper.addfs('authority', self.archive.authority.fs)
+        if self.archive.api.cache:
+            self.fs_wrapper.addfs('cache', self.archive.api.cache.fs)
+        
+        # Add a temporary filesystem as the write filesystem
+        self.temp_fs = TempFS()
+        self.fs_wrapper.setwritefs(self.temp_fs)
+        
+    def open(self):
+        self._get_file_wrapper()
+        
+        return self.fs_wrapper.open(self.archive.service_path, *self.args, **self.kwargs)
+
+    def get_sys_path(self):
+        self._get_file_wrapper()
+
+        #  create a temporary file and save the data to the temporary file
+        self.temp_fs = TempFS()
+        fs.utils.copyfile(self.fs_wrapper, self.service_path, self.temp_fs, self.service_path)
+
+        return self.temp_fs.getsyspath(self.service_path)
 
 
-    def remove(self, *args, **kwargs):
-        '''
-        Remove an existing file
-        '''
-        self.fs.remove(self.path, *args, **kwargs)
+    def close(self):
+        # If nothing was written, exit
+        if not self.temp_fs.exists(self.archive.service_path):
+            self.temp_fs.close()
+            return True
+
+        # If cache exists:
+        if self.cache:
+
+            # Move the file to the cache before uploading
+            fs.utils.movefile(self.temp_fs, self.archive.service_path, self.archive.api.cache.fs, self.archive.service_path)
+
+            # Update the archive with the new version
+            self.archive.update(self.archive.api.cache.fs.getsyspath(self.archive.service_path))
+
+        else:
+            # Update the archive with the new version
+            self.archive.update(self.temp_fs.getsyspath(self.archive.service_path))
 
 
-    def rename(self, *args, **kwargs):
-        '''
-        Atomically rename a file or directory
-        '''
-        self.fs.rename(self.path, *args, **kwargs)
+        self.temp_fs.close()
+        return True
+
+    
+class DataFile(BaseVersionedFile):
+    def __enter__(self):
+        return self.open()
+
+    def __exit__(self, exception_type, exception_value, traceback):
+        self.close()
+        return True
 
 
-    def getinfo(self, *args, **kwargs):
-        '''
-        Return information about the path e.g. size, mtime
-        '''
-        self.fs.getinfo(self.path, *args, **kwargs)
+class LocalFile(DataFile):
+    def __enter__(self):
+        return self.get_sys_path()
 
-
-    def copy(self, *args, **kwargs):
-        '''
-        Copy a file to a new location
-        '''
-
-        self.fs.copy(self.path, *args, **kwargs)
-
-
-    def desc(self, *args, **kwargs):
-        '''
-        Return a short descriptive text regarding a path
-        '''
-
-        self.fs.desc(self.path, *args, **kwargs)
-
-
-    def exists(self, *args, **kwargs):
-        '''
-        Check whether a path exists as file or directory
-        '''
-
-        self.fs.exists(self.path, *args, **kwargs)
-
-
-    def getpathurl(self, *args, **kwargs):
-        '''
-        Get an external URL at which the given file can be accessed, if possible
-        '''
-
-        self.fs.getpathurl(self.path, *args, **kwargs)
-
-
-    def getsyspath(self, *args, **kwargs):
-        '''
-        Get a file's name in the local filesystem, if possible
-        '''
-
-        self.fs.getsyspath(self.path, *args, **kwargs)
-
-
-    def getmeta(self, *args, **kwargs):
-        '''
-        Get the value of a filesystem meta value, if it exists
-        '''
-
-        self.fs.getmeta(self.path, *args, **kwargs)
-
-
-    def getmmap(self, *args, **kwargs):
-        '''
-        Gets an mmap object for the given resource, if supported
-        '''
-
-        self.fs.getmmap(self.path, *args, **kwargs)
-
-
-    def hassyspath(self, *args, **kwargs):
-        '''
-        Check if a path maps to a system path (recognized by the OS)
-        '''
-
-        self.fs.hassyspath(self.path, *args, **kwargs)
-
-
-    def haspathurl(self, *args, **kwargs):
-        '''
-        Check if a path maps to an external URL
-        '''
-
-        self.fs.haspathurl(self.path, *args, **kwargs)
-
-
-    def hasmeta(self, *args, **kwargs):
-        '''
-        Check if a filesystem meta value exists
-        '''
-
-        self.fs.hasmeta(self.path, *args, **kwargs)
-
-
-    def move(self, *args, **kwargs):
-        '''
-        Move a file to a new location
-        '''
-
-        self.fs.move(self.path, *args, **kwargs)
-
-
-    def settimes(self, *args, **kwargs):
-        '''
-        Sets the accessed and modified times of a path
-        '''
-
-        self.fs.settimes(self.path, *args, **kwargs)
-
-
-
-
+    def __exit__(self, exception_type, exception_value, traceback):
+        self.close()
+        return True

--- a/datafs/core/data_file.py
+++ b/datafs/core/data_file.py
@@ -4,7 +4,9 @@ import tempfile
 from fs.tempfs import TempFS
 from fs.multifs import MultiFS
 
+
 class BaseVersionedFile(object):
+
     def __init__(self, archive, cache=False, *args, **kwargs):
         self.archive = archive
         self.cache = cache
@@ -12,42 +14,49 @@ class BaseVersionedFile(object):
         self.args = args
         self.kwargs = kwargs
 
-
     def _get_file_wrapper(self):
 
         # Check the hash (if one exists) for a local version of the file
         if self.archive.api.cache:
 
             # Delete the file in the local cache if it is out of date.
-            local_hash = self.archive.api.cache.get_hash(self.archive.service_path)
+            local_hash = self.archive.api.cache.get_hash(
+                self.archive.service_path)
             latest_hash = self.archive.latest_hash()
             if local_hash != latest_hash:
                 self.archive.api.cache.fs.remove(self.archive.service_path)
 
-        # Create a read-only wrapper with download priority cache, then authority
+        # Create a read-only wrapper with download priority cache, then
+        # authority
         self.fs_wrapper = MultiFS()
         self.fs_wrapper.addfs('authority', self.archive.authority.fs)
         if self.archive.api.cache:
             self.fs_wrapper.addfs('cache', self.archive.api.cache.fs)
-        
+
         # Add a temporary filesystem as the write filesystem
         self.temp_fs = TempFS()
         self.fs_wrapper.setwritefs(self.temp_fs)
-        
+
     def open(self):
         self._get_file_wrapper()
-        
-        return self.fs_wrapper.open(self.archive.service_path, *self.args, **self.kwargs)
+
+        return self.fs_wrapper.open(
+            self.archive.service_path,
+            *self.args,
+            **self.kwargs)
 
     def get_sys_path(self):
         self._get_file_wrapper()
 
         #  create a temporary file and save the data to the temporary file
         self.temp_fs = TempFS()
-        fs.utils.copyfile(self.fs_wrapper, self.service_path, self.temp_fs, self.service_path)
+        fs.utils.copyfile(
+            self.fs_wrapper,
+            self.service_path,
+            self.temp_fs,
+            self.service_path)
 
         return self.temp_fs.getsyspath(self.service_path)
-
 
     def close(self):
         # If nothing was written, exit
@@ -59,21 +68,29 @@ class BaseVersionedFile(object):
         if self.cache:
 
             # Move the file to the cache before uploading
-            fs.utils.movefile(self.temp_fs, self.archive.service_path, self.archive.api.cache.fs, self.archive.service_path)
+            fs.utils.movefile(
+                self.temp_fs,
+                self.archive.service_path,
+                self.archive.api.cache.fs,
+                self.archive.service_path)
 
             # Update the archive with the new version
-            self.archive.update(self.archive.api.cache.fs.getsyspath(self.archive.service_path))
+            self.archive.update(
+                self.archive.api.cache.fs.getsyspath(
+                    self.archive.service_path))
 
         else:
             # Update the archive with the new version
-            self.archive.update(self.temp_fs.getsyspath(self.archive.service_path))
-
+            self.archive.update(
+                self.temp_fs.getsyspath(
+                    self.archive.service_path))
 
         self.temp_fs.close()
         return True
 
-    
+
 class DataFile(BaseVersionedFile):
+
     def __enter__(self):
         return self.open()
 
@@ -83,6 +100,7 @@ class DataFile(BaseVersionedFile):
 
 
 class LocalFile(DataFile):
+
     def __enter__(self):
         return self.get_sys_path()
 

--- a/datafs/core/data_file.py
+++ b/datafs/core/data_file.py
@@ -1,6 +1,5 @@
 
 import fs.utils
-import tempfile
 from fs.tempfs import TempFS
 from fs.multifs import MultiFS
 

--- a/datafs/managers/manager.py
+++ b/datafs/managers/manager.py
@@ -15,7 +15,7 @@ class BaseDataManager(object):
         self.api = api
 
 
-    def update(self, archive_name, version_id, service_data, **metadata):
+    def update(self, archive_name, checksum, metadata):
         '''
         Register a new version for archive ``archive_name``
 
@@ -24,90 +24,25 @@ class BaseDataManager(object):
             need to implement hash checking to prevent duplicate writes
 
         '''
+        version_metadata = {
+            "author" : self.api.username,
+            "contact" : self.api.contact,
+            "updated" : self.api.create_timestamp(),
+            "checksum" : checksum        
+        }
 
-        version_data = metadata
+        archive_data = metadata
 
-        version_data["author"] = version_data.get("author", self.api.username)
-        version_data["contact"] = version_data.get("contact", self.api.contact)
-        version_data["updated"] = version_data.get("updated", self.api.create_timestamp())
+        self._update(archive_name, archive_data, version_metadata)
 
-        version_data["version_id"] = version_id
-        version_data["services"] = service_data
-
-        self._update(archive_name, version_id, version_data)
-
-    def update_metadata(self, archive_name, **kwargs):
+    def update_metadata(self, archive_name, metadata):
         '''
         Update metadata for archive ``archive_name``
         '''
 
-        self._update_metadata(archive_name, **kwargs)
+        self._update_metadata(archive_name, metadata)
 
-    def get_services_for_version(self, archive_name, version_id):
-        '''
-        Return services available for version ``version_id`` of archive ``archive_name``
-        
-        Returns
-        -------
-        services : list
-            list of available service obejcts
-
-        .. note ::
-
-            this method does not check to make sure the version is available 
-            with this service. This is the responsibility of the consumer of the 
-            service list.
-
-        '''
-
-        self._get_services_for_version(archive_name, version_id)
-
-
-    def get_datafile_from_service(self, archive_name, version_id, service):
-        '''
-        Return a DataFile object from a specific service
-        '''
-
-        return self._get_datafile_from_service(archive_name, version_id, service)
-
-
-    def get_all_version_ids(self, archive_name):
-        '''
-        List version IDs available for ``archive_name``
-
-        Returns
-        -------
-        version_ids : list
-
-        '''
-
-        return self._get_all_version_ids(archive_name)
-
-
-    def get_version(self, archive_name, version_id):
-        '''
-        Retrieve a DataFile for the specified version from available services
-
-        Parameters
-        ----------
-        archive_name : str
-            name of the archive
-
-        version_id : str
-            data version to retrieve from services
-
-        Returns
-        -------
-        version : object
-            DataFile object corresponding to version ``version_id``
-
-        '''
-
-        service_path = self._get_service_path(archive_name, version_id)
-        return self.api.download_service.get_datafile(archive_name, version_id, service_path)
-
-
-    def create_archive(self, archive_name, raise_if_exists=True, **metadata):
+    def create_archive(self, archive_name, authority_name, service_path, raise_if_exists=True, metadata={}):
         '''
         Create a new data archive
 
@@ -123,9 +58,9 @@ class BaseDataManager(object):
         metadata['creation_date'] = metadata.get('creation_date', self.api.create_timestamp())
 
         if raise_if_exists:
-            self._create_archive(archive_name, **metadata)
+            self._create_archive(archive_name, authority_name, service_path, metadata)
         else:
-            self._create_if_not_exists(archive_name, **metadata)
+            self._create_if_not_exists(archive_name, authority_name, service_path, metadata)
 
 
     def get_archive(self, archive_name):
@@ -162,32 +97,20 @@ class BaseDataManager(object):
 
     # Private methods (to be implemented by subclasses of DataManager)
     
-    def _update(self, archive_name, version_id, version_data):
+    def _update(self, archive_name, archive_data):
         raise NotImplementedError('BaseDataManager cannot be used directly. Use a subclass, such as MongoDBManager')
 
-    def _update_metadata(self, archive_name, **kwargs):
+    def _update_metadata(self, archive_name, metadata):
         raise NotImplementedError('BaseDataManager cannot be used directly. Use a subclass, such as MongoDBManager')
 
-    def _get_services_for_version(self, archive_name, version_id):
+    def _create_archive(self, archive_name, authority_name, service_path, metadata):
         raise NotImplementedError('BaseDataManager cannot be used directly. Use a subclass, such as MongoDBManager')
 
-    def _get_datafile_from_service(self, archive_name, version_id, service):
-        raise NotImplementedError('BaseDataManager cannot be used directly. Use a subclass, such as MongoDBManager')
-
-    def _get_all_version_ids(self, archive_name):
-        raise NotImplementedError('BaseDataManager cannot be used directly. Use a subclass, such as MongoDBManager')
-
-    def _create_archive(self, archive_name, **metadata):
-        raise NotImplementedError('BaseDataManager cannot be used directly. Use a subclass, such as MongoDBManager')
-
-    def _create_if_not_exists(self, archive_name, **metadata):
+    def _create_if_not_exists(self, archive_name, authority_name, service_path, metadata):
         raise NotImplementedError('BaseDataManager cannot be used directly. Use a subclass, such as MongoDBManager')
 
     def _get_archive(self, archive_name):
         raise NotImplementedError('BaseDataManager cannot be used directly. Use a subclass, such as MongoDBManager')
 
     def _get_archive_metadata(self, archive_name):
-        raise NotImplementedError('BaseDataManager cannot be used directly. Use a subclass, such as MongoDBManager')
-
-    def _get_service_path(self, archive_name, version_id):
         raise NotImplementedError('BaseDataManager cannot be used directly. Use a subclass, such as MongoDBManager')

--- a/datafs/managers/manager.py
+++ b/datafs/managers/manager.py
@@ -33,7 +33,8 @@ class BaseDataManager(object):
 
         archive_data = metadata
 
-        self._update(archive_name, archive_data, version_metadata)
+        self.update_metadata(archive_name, archive_data)
+        self._update(archive_name, version_metadata)
 
     def update_metadata(self, archive_name, metadata):
         '''

--- a/datafs/managers/manager.py
+++ b/datafs/managers/manager.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import
 import time
 
 
-
 class BaseDataManager(object):
     '''
     Base class for DataManager metadata store objects
@@ -14,13 +13,12 @@ class BaseDataManager(object):
     def __init__(self, api=None):
         self.api = api
 
-
     def update(self, archive_name, checksum, metadata):
         '''
         Register a new version for archive ``archive_name``
 
         .. note ::
-        
+
             need to implement hash checking to prevent duplicate writes
 
         '''
@@ -42,7 +40,13 @@ class BaseDataManager(object):
 
         self._update_metadata(archive_name, metadata)
 
-    def create_archive(self, archive_name, authority_name, service_path, raise_if_exists=True, metadata={}):
+    def create_archive(
+            self,
+            archive_name,
+            authority_name,
+            service_path,
+            raise_if_exists=True,
+            metadata={}):
         '''
         Create a new data archive
 
@@ -55,13 +59,18 @@ class BaseDataManager(object):
 
         metadata['creator'] = metadata.get('creator', self.api.username)
         metadata['contact'] = metadata.get('contact', self.api.contact)
-        metadata['creation_date'] = metadata.get('creation_date', self.api.create_timestamp())
+        metadata['creation_date'] = metadata.get(
+            'creation_date', self.api.create_timestamp())
 
         if raise_if_exists:
-            self._create_archive(archive_name, authority_name, service_path, metadata)
+            self._create_archive(
+                archive_name,
+                authority_name,
+                service_path,
+                metadata)
         else:
-            self._create_if_not_exists(archive_name, authority_name, service_path, metadata)
-
+            self._create_if_not_exists(
+                archive_name, authority_name, service_path, metadata)
 
     def get_archive(self, archive_name):
         '''
@@ -76,7 +85,6 @@ class BaseDataManager(object):
 
         return self._get_archive(archive_name)
 
-
     def get_metadata(self, archive_name):
         '''
         Retrieve the metadata for a given archive
@@ -85,7 +93,7 @@ class BaseDataManager(object):
         ----------
         archive_name : str
             name of the archive to be retrieved
-        
+
         Returns
         -------
         metadata : dict
@@ -94,23 +102,38 @@ class BaseDataManager(object):
 
         return self._get_archive_metadata(archive_name)
 
-
     # Private methods (to be implemented by subclasses of DataManager)
-    
+
     def _update(self, archive_name, archive_data):
-        raise NotImplementedError('BaseDataManager cannot be used directly. Use a subclass, such as MongoDBManager')
+        raise NotImplementedError(
+            'BaseDataManager cannot be used directly. Use a subclass, such as MongoDBManager')
 
     def _update_metadata(self, archive_name, metadata):
-        raise NotImplementedError('BaseDataManager cannot be used directly. Use a subclass, such as MongoDBManager')
+        raise NotImplementedError(
+            'BaseDataManager cannot be used directly. Use a subclass, such as MongoDBManager')
 
-    def _create_archive(self, archive_name, authority_name, service_path, metadata):
-        raise NotImplementedError('BaseDataManager cannot be used directly. Use a subclass, such as MongoDBManager')
+    def _create_archive(
+            self,
+            archive_name,
+            authority_name,
+            service_path,
+            metadata):
+        raise NotImplementedError(
+            'BaseDataManager cannot be used directly. Use a subclass, such as MongoDBManager')
 
-    def _create_if_not_exists(self, archive_name, authority_name, service_path, metadata):
-        raise NotImplementedError('BaseDataManager cannot be used directly. Use a subclass, such as MongoDBManager')
+    def _create_if_not_exists(
+            self,
+            archive_name,
+            authority_name,
+            service_path,
+            metadata):
+        raise NotImplementedError(
+            'BaseDataManager cannot be used directly. Use a subclass, such as MongoDBManager')
 
     def _get_archive(self, archive_name):
-        raise NotImplementedError('BaseDataManager cannot be used directly. Use a subclass, such as MongoDBManager')
+        raise NotImplementedError(
+            'BaseDataManager cannot be used directly. Use a subclass, such as MongoDBManager')
 
     def _get_archive_metadata(self, archive_name):
-        raise NotImplementedError('BaseDataManager cannot be used directly. Use a subclass, such as MongoDBManager')
+        raise NotImplementedError(
+            'BaseDataManager cannot be used directly. Use a subclass, such as MongoDBManager')

--- a/datafs/managers/manager.py
+++ b/datafs/managers/manager.py
@@ -1,6 +1,5 @@
 
 from __future__ import absolute_import
-import time
 
 
 class BaseDataManager(object):
@@ -106,11 +105,11 @@ class BaseDataManager(object):
 
     def _update(self, archive_name, archive_data):
         raise NotImplementedError(
-            'BaseDataManager cannot be used directly. Use a subclass, such as MongoDBManager')
+            'BaseDataManager cannot be used directly. Use a subclass.')
 
     def _update_metadata(self, archive_name, metadata):
         raise NotImplementedError(
-            'BaseDataManager cannot be used directly. Use a subclass, such as MongoDBManager')
+            'BaseDataManager cannot be used directly. Use a subclass.')
 
     def _create_archive(
             self,
@@ -119,7 +118,7 @@ class BaseDataManager(object):
             service_path,
             metadata):
         raise NotImplementedError(
-            'BaseDataManager cannot be used directly. Use a subclass, such as MongoDBManager')
+            'BaseDataManager cannot be used directly. Use a subclass.')
 
     def _create_if_not_exists(
             self,
@@ -128,12 +127,12 @@ class BaseDataManager(object):
             service_path,
             metadata):
         raise NotImplementedError(
-            'BaseDataManager cannot be used directly. Use a subclass, such as MongoDBManager')
+            'BaseDataManager cannot be used directly. Use a subclass.')
 
     def _get_archive(self, archive_name):
         raise NotImplementedError(
-            'BaseDataManager cannot be used directly. Use a subclass, such as MongoDBManager')
+            'BaseDataManager cannot be used directly. Use a subclass.')
 
     def _get_archive_metadata(self, archive_name):
         raise NotImplementedError(
-            'BaseDataManager cannot be used directly. Use a subclass, such as MongoDBManager')
+            'BaseDataManager cannot be used directly. Use a subclass.')

--- a/datafs/managers/manager.py
+++ b/datafs/managers/manager.py
@@ -25,11 +25,10 @@ class BaseDataManager(object):
 
         '''
         version_metadata = {
-            "author" : self.api.username,
-            "contact" : self.api.contact,
-            "updated" : self.api.create_timestamp(),
-            "checksum" : checksum        
-        }
+            "author": self.api.username,
+            "contact": self.api.contact,
+            "updated": self.api.create_timestamp(),
+            "checksum": checksum}
 
         archive_data = metadata
 

--- a/datafs/managers/manager_dynamo.py
+++ b/datafs/managers/manager_dynamo.py
@@ -4,12 +4,12 @@ from datafs.managers.manager import BaseDataManager
 
 
 class DynamoDBManager(BaseDataManager):
+
     def __init__(self, api, *args, **kwargs):
         super(DynamoDBManager, self).__init__(api)
 
-
     # Private methods (to be implemented!)
-    
+
     def _update(self, archive_name, version_id, version_data):
         raise NotImplementedError
 

--- a/datafs/managers/manager_mongo.py
+++ b/datafs/managers/manager_mongo.py
@@ -36,20 +36,26 @@ class MongoDBManager(BaseDataManager):
     *args, **kwargs passed to :py:class:`pymongo.MongoClient`
     '''
 
-    def __init__(self, api=None, *args, **kwargs):
+    def __init__(self, database_name, table_name, api=None, *args, **kwargs):
         super(MongoDBManager, self).__init__(api)
         
         # setup MongoClient
         # Arguments can be passed to the client
         self._client = MongoClient(*args, **kwargs)
 
+        self._database_name = database_name
+        self._table_name = table_name
+
         self._db = None
         self._coll = None
 
-    def _connect(self):
+    @property
+    def database_name(self):
+        return self._database_name
 
-        self._db = self._client[self.api.DatabaseName]
-        self._coll = self._db[self.api.DataTableName]
+    @property
+    def table_name(self):
+        return self._table_name
 
     @property
     def collection(self):
@@ -57,43 +63,33 @@ class MongoDBManager(BaseDataManager):
             self._connect()
 
         return self._coll
+    
+    def _connect(self):
+
+        self._db = self._client[self.database_name]
+        self._coll = self._db[self.table_name]
 
     # Private methods (to be implemented!)
     
     @catch_timeout
-    def _update(self, archive_name, version_id, version_data):
-        self.collection.update({"_id":archive_name}, {"$push":{"versions": version_data}})
+    def _update(self, archive_name, archive_data):
+        self.collection.update({"_id":archive_name}, {"$push":{"versions": archive_data}})
 
-    def _update_metadata(self, archive_name, **kwargs):
-        raise NotImplementedError
-
-    def _get_services_for_version(self, archive_name, version_id):
-        raise NotImplementedError
-
-    def _get_datafile_from_service(self, archive_name, version_id, service):
-        raise NotImplementedError
+    def _update_metadata(self, archive_name, metadata):
+        self.collection.update({"_id":archive_name}, {"$push":{"metadata": metadata}})
 
     @catch_timeout
-    def _get_all_version_ids(self, archive_name):
-        version_doc = self.collection.find_one(
-            {"_id":archive_name}, 
-            projection={"versions.version_id": 1})
+    def _create_archive(self, archive_name, authority_name, service_path, metadata):
 
-        return [ver["version_id"] for ver in version_doc["versions"]]
-
-
-    @catch_timeout
-    def _create_archive(self, archive_name, **metadata):
-
-        doc = {'_id': archive_name, 'versions': []}
-        doc.update(**metadata)
+        doc = {'_id': archive_name, 'authority_name': authority_name, 'service_path': service_path, 'versions': []}
+        doc['metadata'] = metadata
 
         self.collection.insert_one(doc)
 
-    def _create_if_not_exists(self, archive_name, **metadata):
+    def _create_if_not_exists(self, archive_name, authority_name, service_path, metadata):
 
         try:
-            self._create_archive(archive_name, **metadata)
+            self._create_archive(archive_name, authority_name, service_path, metadata)
         except DuplicateKeyError:
             pass
 
@@ -108,34 +104,18 @@ class MongoDBManager(BaseDataManager):
         '''
 
         return self.collection.find_one({'_id': archive_name})
-
-
-    @catch_timeout
-    def _get_all_service_paths(self, archive_name):
-        
-        version_doc = self.collection.find_one(
-            {"_id":archive_name}, 
-            projection={"versions": 1})
-
-        return {ver['version_id']: ver['service_path'] for ver in version_doc["versions"]}
-
-
-    def _get_service_path(self, archive_name, version_id):
-
-        return self._get_all_service_paths(archive_name)[version_id]
-
-
-    def _get_archive_metadata(self, archive_name):
-
-        res = self._get_archive_listing(archive_name)
-        
-        return {k: v for k, v in res.items() if k not in ['_id', 'versions']}
         
     @catch_timeout
     def _get_archive(self, archive_name):
 
         res = self.collection.find_one({'_id': archive_name})
         
-        return DataArchive(api = self.api, archive_name=res['_id'])
+        return DataArchive(api = self.api, archive_name=res['_id'], authority=res['authority_name'], service_path=res['service_path'])
+
+    def _get_archive_metadata(self, archive_name):
+
+        res = self._get_archive_listing(archive_name)
+        
+        return res['metadata']
 
         

--- a/datafs/managers/manager_mongo.py
+++ b/datafs/managers/manager_mongo.py
@@ -7,8 +7,6 @@ from datafs.core.data_archive import DataArchive
 from pymongo import MongoClient
 from pymongo.errors import ServerSelectionTimeoutError, DuplicateKeyError
 
-import logging
-
 
 class ConnectionError(IOError):
     pass
@@ -20,10 +18,16 @@ def catch_timeout(func):
     '''
 
     def inner(*args, **kwargs):
+        msg = ' '.join([
+            'Connection to MongoDB server could not be established.',
+            'Make sure you are running a MongoDB server and that the MongoDB',
+            'Manager has been configured to connect over the correct port.',
+            'For more information see',
+            'https://docs.mongodb.com/manual/tutorial/.'])
         try:
             return func(*args, **kwargs)
-        except ServerSelectionTimeoutError as e:
-            raise ConnectionError('Connection to MongoDB server could not be established. Make sure you are running a MongoDB server and that the MongoDB Manager has been configured to connect over the correct port. For more information see https://docs.mongodb.com/manual/tutorial/.')
+        except ServerSelectionTimeoutError:
+            raise ConnectionError(msg)
 
     return inner
 

--- a/datafs/managers/manager_mongo.py
+++ b/datafs/managers/manager_mongo.py
@@ -76,7 +76,8 @@ class MongoDBManager(BaseDataManager):
         self.collection.update({"_id":archive_name}, {"$push":{"versions": archive_data}})
 
     def _update_metadata(self, archive_name, metadata):
-        self.collection.update({"_id":archive_name}, {"$push":{"metadata": metadata}})
+        for key, val in metadata.items():
+            self.collection.update({"_id":archive_name}, {"$set":{"metadata.{}".format(key): val}})
 
     @catch_timeout
     def _create_archive(self, archive_name, authority_name, service_path, metadata):

--- a/datafs/services/service.py
+++ b/datafs/services/service.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 
 import os
 import fs.utils
+import fs.path
 from fs.osfs import OSFS
 from fs.base import FS
 
@@ -16,6 +17,7 @@ class DataService(object):
 
     def upload(self, filepath, service_path):
         local = OSFS(os.path.dirname(filepath))
+        self.fs.makedir(fs.path.dirname(service_path), recursive=True, allow_recreate=True)
         fs.utils.copyfile(local, os.path.basename(filepath), self.fs, service_path)
 
 

--- a/datafs/services/service.py
+++ b/datafs/services/service.py
@@ -9,6 +9,7 @@ from fs.base import FS
 
 from datafs.core.data_file import DataFile
 
+
 class DataService(object):
 
     def __init__(self, fs, api=None):
@@ -17,11 +18,22 @@ class DataService(object):
 
     def upload(self, filepath, service_path):
         local = OSFS(os.path.dirname(filepath))
-        self.fs.makedir(fs.path.dirname(service_path), recursive=True, allow_recreate=True)
-        fs.utils.copyfile(local, os.path.basename(filepath), self.fs, service_path)
-
+        self.fs.makedir(
+            fs.path.dirname(service_path),
+            recursive=True,
+            allow_recreate=True)
+        fs.utils.copyfile(
+            local,
+            os.path.basename(filepath),
+            self.fs,
+            service_path)
 
 
 def CachingService(DataService):
     def cache(self, authority, service_path):
-        fs.utils.copyfile(authority.fs, service_path, self.fs, service_path, overwrite=True)
+        fs.utils.copyfile(
+            authority.fs,
+            service_path,
+            self.fs,
+            service_path,
+            overwrite=True)

--- a/datafs/services/service.py
+++ b/datafs/services/service.py
@@ -5,9 +5,6 @@ import os
 import fs.utils
 import fs.path
 from fs.osfs import OSFS
-from fs.base import FS
-
-from datafs.core.data_file import DataFile
 
 
 class DataService(object):

--- a/datafs/services/service.py
+++ b/datafs/services/service.py
@@ -14,39 +14,12 @@ class DataService(object):
         self.fs = fs
         self.api = api
 
-    def get_datafile(self, archive_name, version_id, path):
-        '''
-        Retrieve a :py:class:`~datafs.core.data_file.DataFile` object
+    def upload(self, filepath, service_path):
+        local = OSFS(os.path.dirname(filepath))
+        fs.utils.copyfile(local, os.path.basename(filepath), self.fs, service_path)
 
-        Parameters
-        ----------
-        path : str
-            path to the requested file, relative to the service root
 
-        Returns
-        -------
-        datafile : object
-            :py:class:`~datafs.core.data_file.DataFile` object
-        
-        '''
 
-        return DataFile(self.api, archive_name, version_id, self.fs, path)
-
-    def upload(self, filepath, path):
-        '''
-
-        Returns
-        -------
-        response : dict
-            location of the object and other metadata
-
-        '''
-
-        current_fs = OSFS(os.path.dirname(filepath))
-        current_path = os.path.basename(filepath)
-
-        target_name = path
-
-        self.fs.makedir(fs.path.dirname(target_name), recursive=True, allow_recreate=True)
-        fs.utils.copyfile(current_fs, current_path, self.fs, target_name)
-
+def CachingService(DataService):
+    def cache(self, authority, service_path):
+        fs.utils.copyfile(authority.fs, service_path, self.fs, service_path, overwrite=True)

--- a/examples/local.py
+++ b/examples/local.py
@@ -180,8 +180,6 @@ def retrieve_from_archive(api):
     with var.open() as f:
          print(f.read())
 
-
-@expect.stdout(test=lambda x: len(literal_eval(x)) == 2)
 def update_archive(api):
     '''
     Updating the archive
@@ -219,7 +217,7 @@ def retrieving_the_latest_version(api):
 
     var = api.get_archive('my_first_archive')
 
-    with var.latest.open() as f:
+    with var.open() as f:
          print(f.read())
 
     # Looks good!

--- a/examples/local.py
+++ b/examples/local.py
@@ -72,7 +72,10 @@ def attach_manager(api):
     
     '''
 
-    manager = MongoDBManager()
+    manager = MongoDBManager(
+        database_name = 'MyDatabase',
+        table_name = 'DataFiles'
+    )
 
     api.attach_manager(manager)
 
@@ -100,7 +103,7 @@ def attach_service(api, local_dir):
 
     # We attach this file to the api and give it a name:
 
-    api.attach_service('local', local)
+    api.attach_authority('local', local)
 
 def create_archive(api):
     '''
@@ -116,7 +119,7 @@ def create_archive(api):
 
     api.create_archive(
         'my_first_archive',
-        description = 'My test data archive')
+        metadata = dict(description = 'My test data archive'))
 
 
 @expect.stdout(test=lambda x: literal_eval(x)['description'] == 'My test data archive')
@@ -162,22 +165,6 @@ def add_to_archive(api):
     os.remove('test.txt')
 
 
-@expect.stdout(test=lambda x: len(literal_eval(x)) == 1)
-def query_archive(api):
-    '''
-    Query archive
-    ~~~~~~~~~~~~~
-    '''
-
-    # Let's make sure the file is still in the archive:
-
-    var = api.get_archive('my_first_archive')
-
-    # List the archive's version IDs
-
-    print(var.version_ids)
-
-
 @expect.stdout('this is a test')
 def retrieve_from_archive(api):
     '''
@@ -190,7 +177,7 @@ def retrieve_from_archive(api):
     
     var = api.get_archive('my_first_archive')
 
-    with var.versions[0].open() as f:
+    with var.open() as f:
          print(f.read())
 
 
@@ -218,10 +205,6 @@ def update_archive(api):
     # Remove the file from the current directory
 
     os.remove('newversion.txt')
-
-    # List the archive's version IDs
-
-    print(var.version_ids)
 
 
 @expect.stdout('this is the next test')
@@ -257,7 +240,6 @@ def run_local_example(local_dir):
     create_archive(api)
     retrieve_archive(api)
     add_to_archive(api)
-    query_archive(api)
     retrieve_from_archive(api)
     update_archive(api)
     retrieving_the_latest_version(api)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-fs==0.5.4
+git+https://github.com/PyFilesystem/pyfilesystem/blob/master/fs/s3fs.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/PyFilesystem/pyfilesystem/blob/master/fs/s3fs.py
+git+https://github.com/PyFilesystem/pyfilesystem.git

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -9,6 +9,5 @@ Sphinx==1.4.9
 cryptography==1.6
 PyYAML==3.12
 pytest==3.0.4
-pytest_cov==2.4.0
 pymongo==3.4.0
 git+https://github.com/PyFilesystem/pyfilesystem.git

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,6 +6,7 @@ flake8==3.2.1
 tox==2.5.0
 coverage==4.2
 Sphinx==1.4.9
+sphinx_rtd_theme=0.1.10a0
 cryptography==1.6
 PyYAML==3.12
 pytest==3.0.4

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,7 +6,7 @@ flake8==3.2.1
 tox==2.5.0
 coverage==4.2
 Sphinx==1.4.9
-sphinx_rtd_theme=0.1.10a0
+sphinx_rtd_theme==0.1.10a0
 cryptography==1.6
 PyYAML==3.12
 pytest==3.0.4

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -9,5 +9,5 @@ Sphinx==1.4.9
 cryptography==1.6
 PyYAML==3.12
 pytest==3.0.4
-fs==0.5.4
 pymongo==3.4.0
+git+https://github.com/PyFilesystem/pyfilesystem/blob/master/fs/s3fs.py

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -9,5 +9,6 @@ Sphinx==1.4.9
 cryptography==1.6
 PyYAML==3.12
 pytest==3.0.4
+pytest_cov==2.4.0
 pymongo==3.4.0
-git+https://github.com/PyFilesystem/pyfilesystem/blob/master/fs/s3fs.py
+git+https://github.com/PyFilesystem/pyfilesystem.git

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -5,6 +5,7 @@ flake8==3.2.1
 tox==2.5.0
 coverage==4.2
 Sphinx==1.4.9
+sphinx_rtd_theme=0.1.10a0
 PyYAML==3.12
 pytest==3.0.4
 pymongo==3.4.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -7,5 +7,5 @@ coverage==4.2
 Sphinx==1.4.9
 PyYAML==3.12
 pytest==3.0.4
-fs==0.5.4
 pymongo==3.4.0
+git+https://github.com/PyFilesystem/pyfilesystem/blob/master/fs/s3fs.py

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -7,6 +7,5 @@ coverage==4.2
 Sphinx==1.4.9
 PyYAML==3.12
 pytest==3.0.4
-pytest_cov==2.4.0
 pymongo==3.4.0
 git+https://github.com/PyFilesystem/pyfilesystem.git

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -5,7 +5,7 @@ flake8==3.2.1
 tox==2.5.0
 coverage==4.2
 Sphinx==1.4.9
-sphinx_rtd_theme=0.1.10a0
+sphinx_rtd_theme==0.1.10a0
 PyYAML==3.12
 pytest==3.0.4
 pymongo==3.4.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -7,5 +7,6 @@ coverage==4.2
 Sphinx==1.4.9
 PyYAML==3.12
 pytest==3.0.4
+pytest_cov==2.4.0
 pymongo==3.4.0
-git+https://github.com/PyFilesystem/pyfilesystem/blob/master/fs/s3fs.py
+git+https://github.com/PyFilesystem/pyfilesystem.git

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ test_requirements = [
     'cryptography==1.5.3',
     'PyYAML==3.12',
     'pytest==3.0.4',
+    'pytest_cov==2.4.0',
     'fs==0.5.4',
     'pymongo==3.3.1'
 ]
@@ -52,9 +53,9 @@ setup(
         "Programming Language :: Python :: 2",
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.3'
+        # 'Programming Language :: Python :: 3.4',
+        # 'Programming Language :: Python :: 3.5',
     ],
     test_suite='tests',
     tests_require=test_requirements

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ test_requirements = [
     'cryptography==1.5.3',
     'PyYAML==3.12',
     'pytest==3.0.4',
-    'pytest_cov==2.4.0',
     'fs==0.5.4',
     'pymongo==3.3.1'
 ]

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ test_requirements = [
     'tox==2.5.0',
     'coverage==4.2',
     'cryptography==1.5.3',
+    'sphinx_rtd_theme=0.1.10a0',
     'PyYAML==3.12',
     'pytest==3.0.4',
     'fs==0.5.4',

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ test_requirements = [
     'tox==2.5.0',
     'coverage==4.2',
     'cryptography==1.5.3',
-    'sphinx_rtd_theme=0.1.10a0',
+    'sphinx_rtd_theme==0.1.10a0',
     'PyYAML==3.12',
     'pytest==3.0.4',
     'fs==0.5.4',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py33, py34, py35, flake8
+envlist = py27, py3, flake8
 
 [testenv:flake8]
 basepython=python


### PR DESCRIPTION
Lots of changes in this one. Apologies for the rambling scope.

In this PR:

- Remove explicit version control
- Add hash testing before upload (addresses #4)
- Check hash before using cache on download
- Add context manager for version-controlled file read/write
- Add context manager for version-controlled file download using `fs.tempfs`
- Remove python 3.4 and 3.5 support in anticipation of boto conficts
- Run `autopep8` and clean up whitespace/imports/formatting across package

Still need:

- Testing/examples for file read/write context managers
- Testing/examples for streaming vs. filepath-based read/write
- Testing/examples for combined authority+cache system