### PR TITLE
Version metadata

### DIFF
--- a/datafs/config/constructor.py
+++ b/datafs/config/constructor.py
@@ -112,8 +112,8 @@ class APIConstructor(object):
         >>> from datafs.managers.manager_dynamo import DynamoDBManager
         >>> assert isinstance(mgr, DynamoDBManager)
         >>>
-        >>> mgr.table_names
-        []
+        >>> 'data-from-yaml' in mgr.table_names
+        False
         >>> mgr.create_archive_table('data-from-yaml')
         >>> print(mgr.table_names[0])
         data-from-yaml

--- a/datafs/core/data_archive.py
+++ b/datafs/core/data_archive.py
@@ -143,7 +143,7 @@ class DataArchive(object):
 
     @property
     def history(self):
-        return self.api.manager.get_versions(self.archive_name)
+        return self.api.manager.get_version_history(self.archive_name)
 
     def update(
         self, 

--- a/datafs/core/data_archive.py
+++ b/datafs/core/data_archive.py
@@ -118,8 +118,7 @@ class DataArchive(object):
     def metadata(self):
         return self.api.manager.get_metadata(self.archive_name)
 
-    @property
-    def latest_hash(self):
+    def get_latest_hash(self):
         return self.api.manager.get_latest_hash(self.archive_name)
 
     def get_version_hash(self, version=None):
@@ -138,7 +137,7 @@ class DataArchive(object):
                 version))
 
         else:
-            return self.latest_hash
+            return self.get_latest_hash()
 
 
     @property
@@ -197,7 +196,7 @@ class DataArchive(object):
         checksum = hashval['checksum']
         algorithm = hashval['algorithm']
 
-        if checksum == self.latest_hash:
+        if checksum == self.get_latest_hash():
             self.update_metadata(kwargs)
 
             if remove and os.path.isfile(filepath):

--- a/datafs/core/data_archive.py
+++ b/datafs/core/data_archive.py
@@ -573,3 +573,20 @@ class DataArchive(object):
 
         if self.api.cache.fs.isfile(self.get_version_path(version)):
             self.api.cache.fs.remove(self.get_version_path(version))
+
+    def get_dependencies(self, version=None):
+        '''
+        Parameters
+        ----------
+        version: str
+            string representing version number whose dependencies you are looking up
+        '''
+
+        if version is None:
+            raise ValueError('No version provided')
+
+        for  i,v in enumerate(self.history):
+            if v['version'] == version:
+                return self.history[i]['dependencies']
+
+

--- a/datafs/core/data_archive.py
+++ b/datafs/core/data_archive.py
@@ -44,7 +44,7 @@ class DataArchive(object):
         if not self.versioned:
             return [None]
 
-        versions = self.history
+        versions = self.get_history()
     
         if len(versions) == 0:
             return []
@@ -118,6 +118,10 @@ class DataArchive(object):
     def metadata(self):
         return self.api.manager.get_metadata(self.archive_name)
 
+
+    def get_history(self):
+        return self.api.manager.get_version_history(self.archive_name)
+
     def get_latest_hash(self):
         return self.api.manager.get_latest_hash(self.archive_name)
 
@@ -129,7 +133,7 @@ class DataArchive(object):
             if version is None:
                 return None
 
-            for ver in self.history:
+            for ver in self.get_history():
                 if BumpableVersion(ver['version']) == version:
                     return ver['checksum']
 
@@ -139,10 +143,6 @@ class DataArchive(object):
         else:
             return self.get_latest_hash()
 
-
-    @property
-    def history(self):
-        return self.api.manager.get_version_history(self.archive_name)
 
     def update(
         self, 
@@ -584,8 +584,8 @@ class DataArchive(object):
         if version is None:
             raise ValueError('No version provided')
 
-        for i,v in enumerate(self.history):
+        for i,v in enumerate(self.get_history()):
             if v['version'] == version:
-                return self.history[i]['dependencies']
+                return self.get_history()[i]['dependencies']
 
 

--- a/datafs/core/data_archive.py
+++ b/datafs/core/data_archive.py
@@ -585,7 +585,7 @@ class DataArchive(object):
         if version is None:
             raise ValueError('No version provided')
 
-        for  i,v in enumerate(self.history):
+        for i,v in enumerate(self.history):
             if v['version'] == version:
                 return self.history[i]['dependencies']
 

--- a/datafs/core/data_archive.py
+++ b/datafs/core/data_archive.py
@@ -114,8 +114,8 @@ class DataArchive(object):
     def archive_path(self):
         return self._archive_path
 
-    @property
-    def metadata(self):
+    
+    def get_metadata(self):
         return self.api.manager.get_metadata(self.archive_name)
 
 

--- a/datafs/core/data_archive.py
+++ b/datafs/core/data_archive.py
@@ -30,7 +30,7 @@ class DataArchive(object):
     
     def get_latest_version(self):
 
-        versions = self.versions
+        versions = self.get_versions()
     
         if len(versions) == 0:
             return None
@@ -38,8 +38,8 @@ class DataArchive(object):
         else:
             return max(versions)
 
-    @property
-    def versions(self):
+    
+    def get_versions(self):
 
         if not self.versioned:
             return [None]
@@ -474,7 +474,7 @@ class DataArchive(object):
 
         '''
 
-        for version in self.versions:
+        for version in self.get_versions():
             if self.authority.fs.exists(self.get_version_path(version)):
                 self.authority.fs.remove(self.get_version_path(version))
 

--- a/datafs/core/data_archive.py
+++ b/datafs/core/data_archive.py
@@ -27,8 +27,8 @@ class DataArchive(object):
     def versioned(self):
         return self._versioned
 
-    @property
-    def latest_version(self):
+    
+    def get_latest_version(self):
 
         versions = self.versions
     
@@ -91,7 +91,7 @@ class DataArchive(object):
 
         if self.versioned:
             if version is None:
-                version = self.latest_version
+                version = self.get_latest_version()
 
             if version is None:
                 return fs.path.join(self.archive_path, str(BumpableVersion()))
@@ -125,7 +125,7 @@ class DataArchive(object):
     def get_version_hash(self, version=None):
         if self.versioned:
             if version is None:
-                version = self.latest_version
+                version = self.get_latest_version()
 
             if version is None:
                 return None
@@ -190,7 +190,7 @@ class DataArchive(object):
 
         '''
 
-        latest_version = self.latest_version
+        latest_version = self.get_latest_version()
 
         hashval = self.api.hash_file(filepath)
 
@@ -285,11 +285,11 @@ class DataArchive(object):
         
         '''
         if version is None:
-            latest_version = self.latest_version
+            latest_version = self.get_latest_version()
             version = latest_version
 
         else:
-            latest_version = self.latest_version
+            latest_version = self.get_latest_version()
 
         version_hash = self.get_version_hash(version)
 
@@ -366,11 +366,11 @@ class DataArchive(object):
 
         '''
         if version is None:
-            latest_version = self.latest_version
+            latest_version = self.get_latest_version()
             version = latest_version
 
         else:
-            latest_version = self.latest_version
+            latest_version = self.get_latest_version()
 
         version_hash = self.get_version_hash(version)
 
@@ -427,7 +427,7 @@ class DataArchive(object):
         '''
 
         if version is None:
-            version = self.latest_version
+            version = self.get_latest_version()
 
         dirname, filename= os.path.split(
             os.path.abspath(os.path.expanduser(filepath)))
@@ -544,7 +544,7 @@ class DataArchive(object):
         '''
 
         if version is None:
-            version = self.latest_version
+            version = self.get_latest_version()
 
         if self.api.cache and self.api.cache.fs.isfile(self.get_version_path(version)):
             return True
@@ -557,7 +557,7 @@ class DataArchive(object):
             raise ValueError('No cache attached')
 
         if version is None:
-            version = self.latest_version
+            version = self.get_latest_version()
 
         if not self.api.cache.fs.isfile(self.get_version_path(version)):
             data_file._touch(self.api.cache.fs, self.get_version_path(version))
@@ -569,7 +569,7 @@ class DataArchive(object):
     def remove_from_cache(self, version=None):
 
         if version is None:
-            version = self.latest_version
+            version = self.get_latest_version()
 
         if self.api.cache.fs.isfile(self.get_version_path(version)):
             self.api.cache.fs.remove(self.get_version_path(version))

--- a/datafs/core/data_file.py
+++ b/datafs/core/data_file.py
@@ -226,7 +226,7 @@ def open_file(
                         fs.utils.copyfile(
                             write_fs, read_path, authority.fs, write_path)
 
-                    update(checksum=checksum)
+                    update(**checksum)
 
         else:
 
@@ -303,7 +303,7 @@ def get_local_path(
                         _makedirs(authority.fs, fs.path.dirname(write_path))
                         fs.utils.copyfile(
                             write_fs, read_path, authority.fs, write_path)
-                    update(checksum=checksum)
+                    update(**checksum)
 
             else:
                 raise OSError(

--- a/datafs/datafs.py
+++ b/datafs/datafs.py
@@ -187,7 +187,7 @@ def download(ctx, archive_name, filepath, version):
 @click.pass_context
 def metadata(ctx, archive_name):
     var = ctx.obj.api.get_archive(archive_name)
-    click.echo(pprint.pformat(var.metadata))
+    click.echo(pprint.pformat(var.get_metadata()))
 
 
 @cli.command()

--- a/datafs/datafs.py
+++ b/datafs/datafs.py
@@ -148,10 +148,10 @@ def upload(ctx, archive_name, filepath, bumpversion='patch', prerelease=None):
     kwargs = parse_args_as_kwargs(ctx.args)
 
     var = ctx.obj.api.get_archive(archive_name)
-    latest_version = var.latest_version
+    latest_version = var.get_latest_version()
 
     var.update(filepath, bumpversion=bumpversion, prerelease=prerelease, **kwargs)
-    new_version = var.latest_version
+    new_version = var.get_latest_version()
     
     if new_version != latest_version:
         bumpmsg = ' version bumped {} --> {}.'.format(latest_version, new_version)
@@ -172,7 +172,7 @@ def download(ctx, archive_name, filepath, version):
     var = ctx.obj.api.get_archive(archive_name)
 
     if version is None:
-        version = var.latest_version
+        version = var.get_latest_version()
 
     var.download(filepath, version=version)
 

--- a/datafs/managers/manager.py
+++ b/datafs/managers/manager.py
@@ -159,7 +159,7 @@ class BaseDataManager(object):
             'authority_name': authority_name,
             'archive_path': archive_path,
             'versioned': versioned,
-            'versions': [],
+            'version_history': [],
             'archive_data': metadata
         }
         archive_metadata.update(user_config)
@@ -262,8 +262,8 @@ class BaseDataManager(object):
 
         self._delete_archive_record(archive_name)
 
-    def get_versions(self, archive_name):
-        return self._get_versions(archive_name)
+    def get_version_history(self, archive_name):
+        return self._get_version_history(archive_name)
 
 
     @classmethod
@@ -358,7 +358,7 @@ class BaseDataManager(object):
         raise NotImplementedError(
             'BaseDataManager cannot be used directly. Use a subclass.')
 
-    def _get_versions(self, archive_name):
+    def _get_version_history(self, archive_name):
         raise NotImplementedError(
             'BaseDataManager cannot be used directly. Use a subclass.')
     def _get_document_count(self, table_name):

--- a/datafs/managers/manager.py
+++ b/datafs/managers/manager.py
@@ -171,7 +171,7 @@ class BaseDataManager(object):
         required |= set(self.required_archive_metadata.keys())
 
         for attr in required:
-            assert attr in archive_metadata['archive_data'] or archive_metadata, 'Required attribute "{}" missing from metadata'.format(
+            assert (attr in archive_metadata['archive_data']) or (attr in archive_metadata), 'Required attribute "{}" missing from metadata'.format(
                 attr)
 
         if raise_on_err:

--- a/datafs/managers/manager_dynamo.py
+++ b/datafs/managers/manager_dynamo.py
@@ -281,9 +281,6 @@ class DynamoDBManager(BaseDataManager):
     def _create_archive(
             self,
             archive_name,
-            authority_name,
-            archive_path,
-            versioned,
             metadata):
         '''
         This adds an item in a DynamoDB table corresponding to a S3 object
@@ -307,14 +304,6 @@ class DynamoDBManager(BaseDataManager):
         Coerce underscores to dashes
         '''
 
-        item = {
-            '_id': archive_name,
-            'authority_name': authority_name,
-            'archive_path': archive_path,
-            'versioned': versioned,
-            'versions': [],
-            'archive_data': metadata
-        }
 
         if archive_name in self._get_archive_names():
 
@@ -322,21 +311,15 @@ class DynamoDBManager(BaseDataManager):
                 "{} already exists. Use get_archive() to view".format(archive_name))
 
         else:
-            self._table.put_item(Item=item)
+            self._table.put_item(Item=metadata)
 
     def _create_if_not_exists(
             self,
             archive_name,
-            authority_name,
-            archive_path,
-            versioned,
             metadata):
         try:
             self._create_archive(
                 archive_name,
-                authority_name,
-                archive_path,
-                versioned,
                 metadata)
         except KeyError:
             pass

--- a/datafs/managers/manager_dynamo.py
+++ b/datafs/managers/manager_dynamo.py
@@ -64,7 +64,7 @@ class DynamoDBManager(BaseDataManager):
                 AttributesToGet=['_id'])['Items']]
             return res
 
-    def _update(self, archive_name, versions):
+    def _update(self, archive_name, version_metadata):
         '''
         Updates the version specific metadata attribute in DynamoDB
         In DynamoDB this is simply a list append on this attribute value
@@ -74,20 +74,20 @@ class DynamoDBManager(BaseDataManager):
         archive_name: str
             unique '_id' primary key
 
-        versions: dict
+        version_metadata: dict
             dictionary of version metadata values
 
         Returns
         -------
         dict
-            list of dictionaries of versions
+            list of dictionaries of version_history
         '''
         self._table.update_item(
             Key={
                 '_id': archive_name},
-            UpdateExpression="SET versions = list_append(versions, :v)",
+            UpdateExpression="SET version_history = list_append(version_history, :v)",
             ExpressionAttributeValues={
-                ':v': [versions]},
+                ':v': [version_metadata]},
             ReturnValues='ALL_NEW')
 
     def _get_table_names(self):
@@ -362,21 +362,21 @@ class DynamoDBManager(BaseDataManager):
 
         return res['archive_path']
 
-    def _get_versions(self, archive_name):
+    def _get_version_history(self, archive_name):
 
         res = self._get_archive_listing(archive_name)
 
-        return res['versions']
+        return res['version_history']
 
     def _get_latest_hash(self, archive_name):
 
-        versions = self._get_versions(archive_name)
+        version_history = self._get_version_history(archive_name)
 
-        if len(versions) == 0:
+        if len(version_history) == 0:
             return None
 
         else:
-            return versions[-1]['checksum']
+            return version_history[-1]['checksum']
 
     def _get_required_user_config(self):
 

--- a/datafs/managers/manager_mongo.py
+++ b/datafs/managers/manager_mongo.py
@@ -150,7 +150,7 @@ class MongoDBManager(BaseDataManager):
     def _update_metadata(self, archive_name, metadata):
         for key, val in metadata.items():
             self.collection.update({"_id": archive_name},
-                                   {"$set": {"metadata.{}".format(key): val}})
+                                   {"$set": {"archive_data.{}".format(key): val}})
 
     def _update_spec_config(self,document_name, spec):
 
@@ -165,38 +165,22 @@ class MongoDBManager(BaseDataManager):
     def _create_archive(
             self,
             archive_name,
-            authority_name,
-            archive_path,
-            versioned,
             metadata):
 
-        doc = {
-            '_id': archive_name,
-            'authority_name': authority_name,
-            'archive_path': archive_path,
-            'versioned': versioned,
-            'versions': []}
-        doc['metadata'] = metadata
 
         try:
-            self.collection.insert_one(doc)
+            self.collection.insert_one(metadata)
         except DuplicateKeyError:
             raise KeyError('Archive "{}" already exists'.format(archive_name))
 
     def _create_if_not_exists(
             self,
             archive_name,
-            authority_name,
-            archive_path,
-            versioned,
             metadata):
 
         try:
             self._create_archive(
                 archive_name,
-                authority_name,
-                archive_path,
-                versioned,
                 metadata)
 
         except KeyError:
@@ -270,7 +254,7 @@ class MongoDBManager(BaseDataManager):
         if res is None:
             raise KeyError
 
-        return res['metadata']
+        return res['archive_data']
 
     def _get_versions(self, archive_name):
 

--- a/datafs/managers/manager_mongo.py
+++ b/datafs/managers/manager_mongo.py
@@ -145,7 +145,7 @@ class MongoDBManager(BaseDataManager):
     @catch_timeout
     def _update(self, archive_name, archive_data):
         self.collection.update({"_id": archive_name},
-                               {"$push": {"versions": archive_data}})
+                               {"$push": {"version_history": archive_data}})
 
     def _update_metadata(self, archive_name, metadata):
         for key, val in metadata.items():
@@ -256,24 +256,24 @@ class MongoDBManager(BaseDataManager):
 
         return res['archive_data']
 
-    def _get_versions(self, archive_name):
+    def _get_version_history(self, archive_name):
 
         res = self.collection.find_one({'_id': archive_name})
 
         if res is None:
             raise KeyError
 
-        return res['versions']
+        return res['version_history']
 
     def _get_latest_hash(self, archive_name):
 
-        versions = self._get_versions(archive_name)
+        version_history = self._get_version_history(archive_name)
 
-        if len(versions) == 0:
+        if len(version_history) == 0:
             return None
 
         else:
-            return versions[-1]['checksum']
+            return version_history[-1]['checksum']
 
     def _delete_archive_record(self, archive_name):
 

--- a/examples/local.py
+++ b/examples/local.py
@@ -138,7 +138,7 @@ property:
 
 .. code-block:: python
 
-    >>> print(var.metadata['description'])
+    >>> print(var.get_metadata()['description'])
     My test data archive
 
 Add a file to the archive

--- a/examples/s3.py
+++ b/examples/s3.py
@@ -151,7 +151,7 @@ property:
 
 .. code-block:: python
 
-    >>> print(var.metadata['description'])
+    >>> print(var.get_metadata()['description'])
     My test data archive
 
 Add a file to the archive

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -223,6 +223,7 @@ def api_with_spec(manager_with_spec):
 
         yield api
 
+
 @pytest.fixture
 def opener(open_func):
     '''
@@ -240,6 +241,7 @@ def opener(open_func):
             version=None, 
             bumpversion='patch', 
             prerelease=None, 
+            dependencies=None,
             *args, 
             **kwargs):
 
@@ -248,7 +250,8 @@ def opener(open_func):
                 mode=mode,
                 version=version, 
                 bumpversion=bumpversion, 
-                prerelease=prerelease, 
+                prerelease=prerelease,
+                dependencies=dependencies, 
                 **kwargs) as f:
                 
                 yield f
@@ -264,13 +267,15 @@ def opener(open_func):
             version=None, 
             bumpversion='patch', 
             prerelease=None, 
+            dependencies=None,
             *args, 
             **kwargs):
 
             with archive.get_local_path(
                 version=version, 
                 bumpversion=bumpversion, 
-                prerelease=prerelease) as fp:
+                prerelease=prerelease,
+                dependencies=dependencies) as fp:
                 
                 with open(fp, mode=mode, *args, **kwargs) as f:
                     yield f

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -192,14 +192,11 @@ def manager_with_spec(mgr_name):
 
 
         metadata_config = {
-            'item1': 'test_string1',
-            'item2': 'test_string2',
-            'item3': 'test_string3'
-        }
+            'description': 'some metadata'
+            }
 
         user_config = {
             'username': 'Your Name',
-            'Home Institution': 'Your Institution',
             'contact': 'my.email@example.com'
             
         }

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -222,12 +222,12 @@ def test_multi_api(api1, api2, auth1, cache1, cache2, opener):
 
     with opener(archive1, 'r') as f1:
 
-        assert len(archive1.history) == 7
+        assert len(archive1.get_history()) == 7
         assert u('12345') == u(f1.read(str_length/2))
         
         with opener(archive2, 'w+') as f2:
             f2.write(test_str_2)
 
-        assert len(archive1.history) == 8
+        assert len(archive1.get_history()) == 8
         assert u('67890') == u(f1.read())
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -144,7 +144,7 @@ def test_cli_local(test_config):
     assert result.exit_code == 0
     assert "'description': 'My test data archive'" in result.output or "u'description': u'My test data archive'" in result.output
     #test the api side of the operation
-    assert u'My test data archive' in api2.archives[0].metadata.values()
+    assert u'My test data archive' in api2.archives[0].get_metadata().values()
 
 
 
@@ -176,7 +176,7 @@ def test_cli_local(test_config):
         assert data == 'Hoo Yah! Stay Stoked!'
 
     #lets check to make sure our metadata update also passed through
-    assert 'Surfers Journal' ==  api2.archives[0].metadata['source']
+    assert 'Surfers Journal' ==  api2.archives[0].get_metadata()['source']
 
     
     #test to assert metadata update

--- a/tests/test_data_file.py
+++ b/tests/test_data_file.py
@@ -32,17 +32,17 @@ def get_checker(service, filepath):
         checksum = None
 
     def check(chk):
-        return chk == checksum
+        return chk['checksum'] == checksum
 
     return check
 
 
 def hasher(f):
 
-    return DataAPI.hash_file(f)['checksum']
+    return DataAPI.hash_file(f)
 
 
-def updater(checksum, metadata={}):
+def updater(*args, **kwargs):
     pass
 
 

--- a/tests/test_datafs.py
+++ b/tests/test_datafs.py
@@ -166,7 +166,7 @@ class TestArchiveCreation(object):
         api.create_archive(archive_name, metadata={'testval': 'my test value'})
         var = api.get_archive(archive_name)
 
-        testval = var.metadata['testval']
+        testval = var.get_metadata()['testval']
 
         with pytest.raises(KeyError) as excinfo:
             api.create_archive(archive_name)
@@ -180,12 +180,12 @@ class TestArchiveCreation(object):
             raise_on_err=False)
         var = api.get_archive(archive_name)
 
-        assert testval == var.metadata[
+        assert testval == var.get_metadata()[
             'testval'], "Test archive was incorrectly updated!"
 
         var.update_metadata({'testval': 'a different test value'})
 
-        assert var.metadata[
+        assert var.get_metadata()[
             'testval'] == 'a different test value', "Test archive was not updated!"
 
         # Test archive deletion

--- a/tests/test_datafs.py
+++ b/tests/test_datafs.py
@@ -109,16 +109,16 @@ class TestHashFunction(object):
 
         assert direct == apihash, 'Manual hash "{}" != api hash "{}"'.format(
             direct, apihash)
-        assert direct == archive.latest_hash, 'Manual hash "{}" != archive hash "{}"'.format(
-            direct, archive.latest_hash)
+        assert direct == archive.get_latest_hash(), 'Manual hash "{}" != archive hash "{}"'.format(
+            direct, archive.get_latest_hash())
 
         # Try uploading the same file
         apihash = self.update_and_hash(archive, contents)
 
         assert direct == apihash, 'Manual hash "{}" != api hash "{}"'.format(
             direct, apihash)
-        assert direct == archive.latest_hash, 'Manual hash "{}" != archive hash "{}"'.format(
-            direct, archive.latest_hash)
+        assert direct == archive.get_latest_hash(), 'Manual hash "{}" != archive hash "{}"'.format(
+            direct, archive.get_latest_hash())
 
         # Update and test again!
 
@@ -136,8 +136,8 @@ class TestHashFunction(object):
 
         assert direct == apihash, 'Manual hash "{}" != api hash "{}"'.format(
             direct, apihash)
-        assert direct == archive.latest_hash, 'Manual hash "{}" != archive hash "{}"'.format(
-            direct, archive.latest_hash)
+        assert direct == archive.get_latest_hash(), 'Manual hash "{}" != archive hash "{}"'.format(
+            direct, archive.get_latest_hash())
 
         # Update and test a different way!
 
@@ -154,8 +154,8 @@ class TestHashFunction(object):
         assert contents == current, 'Latest updates "{}" !=  archive contents "{}"'.format(
             contents, current)
 
-        assert direct == archive.latest_hash, 'Manual hash "{}" != archive hash "{}"'.format(
-            direct, archive.latest_hash)
+        assert direct == archive.get_latest_hash(), 'Manual hash "{}" != archive hash "{}"'.format(
+            direct, archive.get_latest_hash())
 
 
 class TestArchiveCreation(object):

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -130,9 +130,9 @@ class TestBaseManager(object):
             base_manager._delete_table('my-data-table')
 
     
-    def test_get_versions(self, base_manager):
+    def test_get_version_history(self, base_manager):
         with pytest.raises(NotImplementedError):
-            base_manager._get_versions('archive 1')
+            base_manager._get_version_history('archive 1')
 
 
     
@@ -206,6 +206,6 @@ class TestBaseManager(object):
             base_manager._delete_table('my-data-table')
 
     
-    def test_get_versions(self, base_manager):
+    def test_get_version_history(self, base_manager):
         with pytest.raises(NotImplementedError):
-            base_manager._get_versions('archive 1')
+            base_manager._get_version_history('archive 1')

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -23,23 +23,20 @@ class TestMetadataRequirements(object):
         assert len(manager_with_spec._get_spec_documents('standalone-test-table')) == 2
 
     def test_spec_config_update_metadata(self,manager_with_spec):
-        assert len(manager_with_spec.required_archive_metadata) == 3
+        assert len(manager_with_spec.required_archive_metadata) == 1
 
     def test_spec_config_update_user_config(self,manager_with_spec):
 
-        assert len(manager_with_spec.required_user_config) == 3
+        assert len(manager_with_spec.required_user_config) == 2
 
     def test_manager_spec_setup(self,api_with_spec, auth1):
 
         metadata_config = {
-            'item1': 'test_string1',
-            'item2': 'test_string2',
-            'item3': 'test_string3'
+            'description': 'test_string1',
         }
 
         user_config = {
             'username': 'My Name',
-            'Home Institution': 'Your Institution', 
             'contact': 'my.email@example.com'
             
         }
@@ -49,18 +46,17 @@ class TestMetadataRequirements(object):
         api_with_spec.create_archive('my_spec_test_archive', metadata=metadata_config)
 
         with pytest.raises(AssertionError) as excinfo:
-            api_with_spec.create_archive('my_other_test_archive', metadata={})
+            api_with_spec.create_archive('my_other_test_archive', metadata={'another_string': 'to break the test'})
 
     def test_manager_spec_setup_api_metadata(self,api_with_spec, auth1):
 
         metadata_config = {
-            'item1': 'test_string1',
-            'item2': 'test_string2',
-            'item3': 'test_string3'
+            'archive_data': 'test_string1',
+
         }
 
         with pytest.raises(AssertionError) as excinfo:
-            api_with_spec.create_archive('my_api_test_archive', metadata=metadata_config)
+            api_with_spec.create_archive('my_api_test_archive', metadata={})
 
 
 class TestBaseManager(object):

--- a/tests/test_version_metadata.py
+++ b/tests/test_version_metadata.py
@@ -5,6 +5,7 @@ from datafs.core.data_archive import DataArchive
 import pytest
 
 
+#hack to get around installing these packages on Travis
 has_special_dependencies = False
 
 try:
@@ -63,7 +64,7 @@ class TestVersionedMetadata(object):
 
 
 		tmin_values = base + 3 * np.random.randn(annual_cycle.size, 3)
-		tmax_values = base + 10 + 3 * np.random.randn(annual_cycle.size, 3)
+		tmax_values = base + 3 * np.random.randn(annual_cycle.size, 3)
 
 
 		ds = xr.Dataset({'tmin': (('time', 'location'), tmin_values), 
@@ -79,24 +80,24 @@ class TestVersionedMetadata(object):
 
 		assert var.history[-1]['dependencies']['arch2'] == '0.2.0'
 
-		#assert len(ds.tmin.shape) > 0
+		assert len(ds.tmin.shape) > 0
 
-		# 	tmin_values = base + 10 * np.random.randn(annual_cycle.size, 10)
-		# 	new_ds = xr.Dataset({'tmin': (('time', 'location'), tmin_values), 
-		# 			 'tmax': (('time', 'location'), tmax_values)},
-	 #                {'time': times, 'location': ['IA', 'IN', 'IL']})
+		tmin_values = base + 10 * np.random.randn(annual_cycle.size, 3)
+		ds.update({'tmin': (('time', 'location'), tmin_values)})
+		
 
-		# 	with var.get_local_path(bumpversion='patch', dependencies={'arch1': '0.1.0', 'arch2': '1.2.0'}) as f:
-		# 		with xr.open_dataset(f) as ds:
+		with var.get_local_path(bumpversion='patch', dependencies={'arch1': '0.1.0', 'arch2': '1.2.0'}) as f:
+			with xr.open_dataset(f) as ds:
 
-		# 			mem = ds.load()
-		# 			ds.close()
-
-
-		# 		mem.attrs['description'] = 'some netcdf description'
-		# 		mem.to_netcdf(f)
+				mem = ds.load()
+				ds.close()
 
 
-		# assert 
+			mem.to_netcdf(f)
+
+
+		assert  var.history[-1]['dependencies']['arch2'] == '1.2.0'
+		assert  var.history[-1]['checksum'] != var.history[-2]['checksum']
+		
 
 

--- a/tests/test_version_metadata.py
+++ b/tests/test_version_metadata.py
@@ -79,7 +79,7 @@ class TestVersionedMetadata(object):
 
 		assert var.history[-1]['dependencies']['arch2'] == '0.2.0'
 
-		assert len(ds.tmin.shape) > 0
+		#assert len(ds.tmin.shape) > 0
 
 		# 	tmin_values = base + 10 * np.random.randn(annual_cycle.size, 10)
 		# 	new_ds = xr.Dataset({'tmin': (('time', 'location'), tmin_values), 

--- a/tests/test_version_metadata.py
+++ b/tests/test_version_metadata.py
@@ -41,13 +41,13 @@ class TestVersionedMetadata(object):
 
 		var.update('test.txt', remove=True, version='patch', dependencies={'arch1': '0.1.0', 'arch2': '0.2.0'})
 
-		assert len(var.history[-1]['dependencies']) == 2
+		assert len(var.get_history()[-1]['dependencies']) == 2
 
 		with opener(var, 'w+', dependencies={'arch2': '0.1.2'}) as f:
 			f.write(u'test and more test')
 
 
-		assert var.history[-1]['dependencies']['arch2'] == '0.1.2'
+		assert var.get_history()[-1]['dependencies']['arch2'] == '0.1.2'
 
 
 		assert len(var.get_dependencies(version='0.0.1')) == 2
@@ -78,7 +78,7 @@ class TestVersionedMetadata(object):
 			ds.to_netcdf(f)
 
 
-		assert var.history[-1]['dependencies']['arch2'] == '0.2.0'
+		assert var.get_history()[-1]['dependencies']['arch2'] == '0.2.0'
 
 		assert len(ds.tmin.shape) > 0
 
@@ -96,8 +96,8 @@ class TestVersionedMetadata(object):
 			mem.to_netcdf(f)
 
 
-		assert  var.history[-1]['dependencies']['arch2'] == '1.2.0'
-		assert  var.history[-1]['checksum'] != var.history[-2]['checksum']
-		
+		assert  var.get_history()[-1]['dependencies']['arch2'] == '1.2.0'
+		assert  var.get_history()[-1]['checksum'] != var.get_history()[-2]['checksum']
+
 
 

--- a/tests/test_version_metadata.py
+++ b/tests/test_version_metadata.py
@@ -1,0 +1,60 @@
+from __future__ import absolute_import
+from datafs.managers.manager import BaseDataManager
+from datafs.core.data_archive import DataArchive
+
+import pytest
+
+
+import xarray as xr
+import numpy as np
+import pandas as pd
+
+
+np.random.seed(123)
+times = pd.date_range('2000-01-01', '2001-12-31', name='time')
+annual_cycle = np.sin(2 * np.pi * (times.dayofyear / 365.25 - 0.28))
+base = 10 + 15 * annual_cycle.reshape(-1, 1)
+
+
+tmin_values = base + 3 * np.random.randn(annual_cycle.size, 3)
+tmax_values = base + 10 + 3 * np.random.randn(annual_cycle.size, 3)
+
+
+ds = xr.Dataset({'tmin': (('time', 'location'), tmin_values), 
+				 'tmax': (('time', 'location'), tmax_values)},
+                {'time': times, 'location': ['IA', 'IN', 'IL']})
+
+
+
+
+class TestVersionedMetadata(object):
+
+	def test_versioned_metadata_open(self, api, opener):
+
+		var = api.create_archive('my_archive')
+		with open('test.txt', 'w+') as f:
+			f.write(u'test test, this is a test')
+
+		var.update('test.txt', remove=True, version='patch', dependencies={'arch1': '0.1.0', 'arch2': '0.2.0'})
+
+		assert len(var.history[-1]['dependencies']) == 2
+
+		with opener(var, 'w+', dependencies={'arch2': '0.1.2'}) as f:
+			f.write(u'test and more test')
+
+
+		assert var.history[-1]['dependencies']['arch2'] == '0.1.2'
+
+
+		assert len(var.get_dependencies(version='0.0.1')) == 2
+
+
+	def test_version_metadata_with_streaming(self,api,opener):
+
+		var = api.create_archive('streaming_test')
+		with var.get_local_path(bumpversion='patch', dependencies ={'arch1': '0.1.0', 'arch2': '0.2.0'}) as f:
+			ds.to_netcdf(f)
+
+
+		assert var.history[-1]['dependencies']['arch2'] == '0.1.2'
+

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -12,7 +12,7 @@ def test_version_tracking(api1, auth1, opener):
     assert archive.versioned, "Archive not versioned, but should be by default"
 
     assert archive.get_latest_version() is None
-    assert len(archive.versions) == 0
+    assert len(archive.get_versions()) == 0
     assert archive.latest_hash is None
     assert archive.get_version_hash() is None
 
@@ -21,7 +21,7 @@ def test_version_tracking(api1, auth1, opener):
         f.write(u('test content v0.0.1a1'))
 
     assert archive.get_latest_version() == '0.0.1a1'
-    assert len(archive.versions) == 1
+    assert len(archive.get_versions()) == 1
     assert archive.latest_hash is not None
     assert archive.get_version_hash('0.0.1a1') == archive.latest_hash
 
@@ -33,7 +33,7 @@ def test_version_tracking(api1, auth1, opener):
         f.write(u('test content v0.1b1'))
 
     assert archive.get_latest_version() == '0.1b1'
-    assert len(archive.versions) == 2
+    assert len(archive.get_versions()) == 2
     assert archive.latest_hash is not None
     assert archive.get_version_hash('0.0.1a1') != archive.latest_hash
     assert archive.get_version_hash('0.1b1') == archive.latest_hash
@@ -48,7 +48,7 @@ def test_version_tracking(api1, auth1, opener):
         f.write(u(' --> v0.1.1'))
 
     assert archive.get_latest_version() == '0.1.1'
-    assert len(archive.versions) == 3
+    assert len(archive.get_versions()) == 3
     assert archive.latest_hash is not None
     assert archive.get_version_hash('0.0.1a1') != archive.latest_hash
     assert archive.get_version_hash('0.1.1') == archive.latest_hash

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -13,7 +13,7 @@ def test_version_tracking(api1, auth1, opener):
 
     assert archive.get_latest_version() is None
     assert len(archive.get_versions()) == 0
-    assert archive.latest_hash is None
+    assert archive.get_latest_hash() is None
     assert archive.get_version_hash() is None
 
 
@@ -22,8 +22,8 @@ def test_version_tracking(api1, auth1, opener):
 
     assert archive.get_latest_version() == '0.0.1a1'
     assert len(archive.get_versions()) == 1
-    assert archive.latest_hash is not None
-    assert archive.get_version_hash('0.0.1a1') == archive.latest_hash
+    assert archive.get_latest_hash() is not None
+    assert archive.get_version_hash('0.0.1a1') == archive.get_latest_hash()
 
     with opener(archive, 'r') as f:
         assert u(f.read()) == u('test content v0.0.1a1')
@@ -34,9 +34,9 @@ def test_version_tracking(api1, auth1, opener):
 
     assert archive.get_latest_version() == '0.1b1'
     assert len(archive.get_versions()) == 2
-    assert archive.latest_hash is not None
-    assert archive.get_version_hash('0.0.1a1') != archive.latest_hash
-    assert archive.get_version_hash('0.1b1') == archive.latest_hash
+    assert archive.get_latest_hash() is not None
+    assert archive.get_version_hash('0.0.1a1') != archive.get_latest_hash()
+    assert archive.get_version_hash('0.1b1') == archive.get_latest_hash()
 
     with opener(archive, 'r') as f:
         assert u(f.read()) == u('test content v0.1b1')
@@ -49,9 +49,9 @@ def test_version_tracking(api1, auth1, opener):
 
     assert archive.get_latest_version() == '0.1.1'
     assert len(archive.get_versions()) == 3
-    assert archive.latest_hash is not None
-    assert archive.get_version_hash('0.0.1a1') != archive.latest_hash
-    assert archive.get_version_hash('0.1.1') == archive.latest_hash
+    assert archive.get_latest_hash() is not None
+    assert archive.get_version_hash('0.0.1a1') != archive.get_latest_hash()
+    assert archive.get_version_hash('0.1.1') == archive.get_latest_hash()
 
     with opener(archive, 'r', version='0.0.1a1') as f:
         assert u(f.read()) == u('test content v0.0.1a1')

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -11,7 +11,7 @@ def test_version_tracking(api1, auth1, opener):
 
     assert archive.versioned, "Archive not versioned, but should be by default"
 
-    assert archive.latest_version is None
+    assert archive.get_latest_version() is None
     assert len(archive.versions) == 0
     assert archive.latest_hash is None
     assert archive.get_version_hash() is None
@@ -20,7 +20,7 @@ def test_version_tracking(api1, auth1, opener):
     with opener(archive, 'w+', prerelease='alpha') as f:
         f.write(u('test content v0.0.1a1'))
 
-    assert archive.latest_version == '0.0.1a1'
+    assert archive.get_latest_version() == '0.0.1a1'
     assert len(archive.versions) == 1
     assert archive.latest_hash is not None
     assert archive.get_version_hash('0.0.1a1') == archive.latest_hash
@@ -32,7 +32,7 @@ def test_version_tracking(api1, auth1, opener):
     with opener(archive, 'w+', bumpversion='minor', prerelease='beta') as f:
         f.write(u('test content v0.1b1'))
 
-    assert archive.latest_version == '0.1b1'
+    assert archive.get_latest_version() == '0.1b1'
     assert len(archive.versions) == 2
     assert archive.latest_hash is not None
     assert archive.get_version_hash('0.0.1a1') != archive.latest_hash
@@ -47,7 +47,7 @@ def test_version_tracking(api1, auth1, opener):
     with opener(archive, 'a', version='0.0.1a1') as f:
         f.write(u(' --> v0.1.1'))
 
-    assert archive.latest_version == '0.1.1'
+    assert archive.get_latest_version() == '0.1.1'
     assert len(archive.versions) == 3
     assert archive.latest_hash is not None
     assert archive.get_version_hash('0.0.1a1') != archive.latest_hash


### PR DESCRIPTION
PR Scope: 

This PR addresses issue: #63, #71, #72: 

1. Dependency arguments and argument handling added to the following modules:

```DataArchive.update()```
``` DataArchive.open()``` 
```DataArchive.get_local_path()```
```BasedataManager.update_manager()```

2. Table schemas have been moved from the dynamo and mongo modules to the BaseDataManager. 

3. `versions` attr is now ```version_history``` in table schema and ```DataArchive.get_versions``` is now ```DataArchive.get_version_history```

4. Properties in manager are now function calls
