### PR TITLE
Explicit metadata

### DIFF
--- a/datafs/core/data_archive.py
+++ b/datafs/core/data_archive.py
@@ -420,7 +420,7 @@ class DataArchive(object):
             yield f
 
     @contextmanager
-    def get_local_path(self, version=None, bumpversion=None, prerelease=None, dependencies=None, metadata={}, *args, **kwargs):
+    def get_local_path(self, version=None, bumpversion=None, prerelease=None, dependencies=None, metadata={}):
         '''
         Returns a local path for read/write
 

--- a/datafs/core/data_archive.py
+++ b/datafs/core/data_archive.py
@@ -192,7 +192,7 @@ class DataArchive(object):
         bumpversion=None, 
         prerelease=None, 
         dependencies=None,
-        **kwargs):
+        metadata={}):
         '''
         Enter a new version to a DataArchive
 
@@ -224,7 +224,9 @@ class DataArchive(object):
             non-None value. If the archive is not versioned, prerelease is 
             ignored.
 
-        kwargs stored as update to metadata.
+        metadata : dict
+            Updates to archive metadata. Pass {key: None} to remove a key from 
+            the archive's metadata.
 
 
         '''
@@ -237,7 +239,7 @@ class DataArchive(object):
         algorithm = hashval['algorithm']
 
         if checksum == self.get_latest_hash():
-            self.update_metadata(kwargs)
+            self.update_metadata(metadata)
 
             if remove and os.path.isfile(filepath):
                 os.remove(filepath)
@@ -269,7 +271,7 @@ class DataArchive(object):
             self.authority.upload(filepath, next_path, remove=remove)
 
         self._update_manager(
-            archive_metadata=kwargs, 
+            archive_metadata=metadata, 
             version_metadata=dict(checksum=checksum, algorithm=algorithm, version=next_version, dependencies=dependencies))
 
     def _get_default_dependencies(self):
@@ -317,7 +319,7 @@ class DataArchive(object):
     # File I/O methods
 
     @contextmanager
-    def open(self, mode='r', version=None, bumpversion=None, prerelease=None, dependencies = None, *args, **kwargs):
+    def open(self, mode='r', version=None, bumpversion=None, prerelease=None, dependencies = None, metadata={}, *args, **kwargs):
         '''
         Opens a file for read/write
 
@@ -344,6 +346,10 @@ class DataArchive(object):
             'beta'. Either bumpversion or prerelease (or both) must be a 
             non-None value. If the archive is not versioned, prerelease is 
             ignored.
+
+        metadata : dict
+            Updates to archive metadata. Pass {key: None} to remove a key from 
+            the archive's metadata.
 
 
         args, kwargs sent to file system opener
@@ -390,8 +396,13 @@ class DataArchive(object):
         version_check = lambda chk: chk['checksum'] == version_hash
 
         # Updater updates the manager with the latest version number
-        updater = lambda **kwargs: self._update_manager(
-            version_metadata=dict(version=next_version, dependencies=dependencies, **kwargs))
+        updater = lambda checksum, algorithm: self._update_manager(
+            archive_metadata=metadata,
+            version_metadata=dict(
+                version=next_version, 
+                dependencies=dependencies, 
+                checksum=checksum, 
+                algorithm=algorithm))
 
         opener = data_file.open_file(
             self.authority,
@@ -409,7 +420,7 @@ class DataArchive(object):
             yield f
 
     @contextmanager
-    def get_local_path(self, version=None, bumpversion=None, prerelease=None, dependencies=None, *args, **kwargs):
+    def get_local_path(self, version=None, bumpversion=None, prerelease=None, dependencies=None, metadata={}, *args, **kwargs):
         '''
         Returns a local path for read/write
 
@@ -433,6 +444,10 @@ class DataArchive(object):
             'beta'. Either bumpversion or prerelease (or both) must be a 
             non-None value. If the archive is not versioned, prerelease is 
             ignored.
+
+        metadata : dict
+            Updates to archive metadata. Pass {key: None} to remove a key from 
+            the archive's metadata.
 
         '''
         if version is None:
@@ -478,8 +493,13 @@ class DataArchive(object):
         version_check = lambda chk: chk['checksum'] == version_hash
 
         # Updater updates the manager with the latest version number
-        updater = lambda **kwargs: self._update_manager(
-            version_metadata=dict(version=next_version, dependencies=dependencies, **kwargs))
+        updater = lambda checksum, algorithm: self._update_manager(
+            archive_metadata=metadata,
+            version_metadata=dict(
+                version=next_version, 
+                dependencies=dependencies, 
+                checksum=checksum, 
+                algorithm=algorithm))
 
         path = data_file.get_local_path(
             self.authority,

--- a/datafs/datafs.py
+++ b/datafs/datafs.py
@@ -11,7 +11,7 @@ from datafs._compat import u
 import os
 import re
 import click
-import yaml
+import sys
 import pprint
 
 
@@ -179,10 +179,6 @@ def update(
     latest_version = var.get_latest_version()
 
     if string:
-        if file is None:
-            contents = raw_input()
-        else:
-            contents = file
 
         with var.open(
             'w+', 
@@ -191,7 +187,11 @@ def update(
             dependencies=dependencies_dict, 
             metadata=kwargs) as f:
 
-            f.write(u(contents))
+            if file is None:
+                for line in sys.stdin:
+                    f.write(u(line))
+            else:
+                f.write(u(file))
 
     else:
         if file is None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -258,20 +258,20 @@ def test_cli_local(test_config):
     
     with runner.isolated_filesystem():
 
-        with open('here.txt', 'w+') as to_update:
-            to_update.write('new version data')
-
-        result = runner.invoke(cli, prefix + ['update', 'my_first_archive', 'here.txt', '--bumpversion', 'minor'])
+        result = runner.invoke(cli, prefix + ['update', 'my_first_archive', '--bumpversion', 'minor', '--string', 'new version data'])
         assert result.exit_code == 0
 
-        os.remove('here.txt')
-
-        result = runner.invoke(cli, prefix + ['download', 'my_first_archive', 'here.txt'])
+        result = runner.invoke(cli, prefix + ['cat', 'my_first_archive'])
         assert result.exit_code == 0
 
-        with open('here.txt', 'r') as downloaded:
-            assert downloaded.read() == 'new version data'
+        'new version data' in result.output
 
+        result = runner.invoke(cli, prefix + ['download', 'my_first_archive', 'here.txt', '--version', '0.0.1'])
+        assert result.exit_code == 0
+
+        'Hoo Yah! Stay Stoked!' in result.output
+
+        # test download of previous version
         result = runner.invoke(cli, prefix + ['download', 'my_first_archive', 'here.txt', '--version', '0.0.1'])
         assert result.exit_code == 0
 
@@ -291,7 +291,13 @@ def test_cli_local(test_config):
 
 
     #teardown
-    api2.archives[0].delete()
+    result = runner.invoke(cli, prefix + ['delete', 'my_first_archive'])
+
+    result = runner.invoke(cli, prefix + ['list'])
+    assert result.exit_code == 0
+    assert [] == ast.literal_eval(result.output)
+
+    assert len(api2.archives) == 0
 
 
 

--- a/tests/test_version_metadata.py
+++ b/tests/test_version_metadata.py
@@ -32,7 +32,7 @@ class TestVersionedMetadata(object):
 
 		var.update(
 			fp, 
-			version='patch', 
+			bumpversion='patch', 
 			dependencies={'arch1': '0.1.0', 'arch2': '0.2.0'})
 
 		with opener(var, 'r') as f:


### PR DESCRIPTION
Major API changes:
* Switch from **kwargs to metadata={} on `DataArchive.update`, `open`, and `get_local_path`

  This fixes numerous bugs arising from the confusion of open(**kwargs), version_metadata(**kwargs), and lambda: **kwargs in the update function sent to `data_file`.

* Added `--string` option to `datafs update` CLI command, which allows you to pass a string or stdin directly into an archive:

  ```bash
  $ datafs create new_archive
  created versioned archive <DataArchive local://new_archive>

  $ datafs update new_archive --string "my first archive contents"
  uploaded data to <DataArchive local://new_archive>. new version 0.0.1 created.

  $ echo "my second update" | datafs update new_archive --string
  uploaded data to <DataArchive local://new_archive>. version bumped 0.0.1 --> 0.0.2.

  ```