### PR TITLE
add regex and unix path-style search utilities

### DIFF
--- a/datafs/__init__.py
+++ b/datafs/__init__.py
@@ -8,7 +8,7 @@ from datafs.config.helpers import get_api, to_config_file
 
 __author__ = """Climate Impact Lab"""
 __email__ = 'jsimcock@rhg.com'
-__version__ = '0.6.4'
+__version__ = '0.6.5'
 
 _module_imports = (
     DataAPI,

--- a/datafs/core/data_api.py
+++ b/datafs/core/data_api.py
@@ -8,7 +8,8 @@ import fs1.path
 
 import os
 import hashlib
-
+import fnmatch
+import re
 
 try:
     PermissionError
@@ -166,14 +167,26 @@ class DataAPI(object):
             **res)
 
 
-    def list(self, substr=None):
+    def list(self, pattern=None, engine='path'):
+    
+        archives =self.manager.get_archive_names()
 
-        archives = self.manager.get_archive_names()
-        if substr:
-            return [a for a in archives if substr in a]
-        else:
+        if not pattern:
             return archives
 
+        if engine == 'str':
+            return [x for x in archives if pattern in x]
+
+        elif engine == 'path':
+            return fnmatch.filter(archives, pattern)
+
+        elif engine == 'regex':
+            return [arch for arch in archives if re.search(pattern, arch)]
+
+        else:
+            raise ValueError(
+                'search engine "{}" not recognized. '.format(engine) +\
+                'choose "str", "fn", or "regex"')
 
     @classmethod
     def create_archive_path(cls, archive_name):

--- a/datafs/datafs.py
+++ b/datafs/datafs.py
@@ -342,12 +342,13 @@ def versions(ctx, archive_name):
 
 
 @cli.command()
-@click.option('--substr', default=None, help='filter archive names with a substring')
+@click.option('--pattern', default=None, help='filter archive names with a match pattern')
+@click.option('--engine', default='path', help='comparison engine: str/path/regex (default path)')
 @click.pass_context
-def list(ctx, substr):
+def list(ctx, pattern, engine):
     _generate_api(ctx)
 
-    matches = ctx.obj.api.list(substr)
+    matches = ctx.obj.api.list(pattern, engine)
     
     if len(matches) > 0:
         click.echo(' '.join(matches))

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.6.4
+current_version = 0.6.5
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ entry_points = '[console_scripts]\ndatafs=datafs.datafs:cli'
 
 setup(
     name='datafs',
-    version='0.6.4',
+    version='0.6.5',
     description="DataFS is an abstraction layer for data storage systems. It manages file versions and metadata using a json-like storage system like AWS's DynamoDB and relies on PyFilesystem to abstract file storage, allowing you to store files locally and on the cloud in a seamless interface.",
     long_description=readme + '\n\n' + history,
     author="Climate Impact Lab",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ import time
 import boto
 import moto
 import os
+import itertools
 
 import fs1.utils
 from fs1.osfs import OSFS
@@ -48,7 +49,7 @@ def pytest_generate_tests(metafunc):
         metafunc.parametrize('open_func', ['open_file', 'get_local_path'])
 
 
-@pytest.yield_fixture(scope='function')
+@pytest.yield_fixture
 def tempdir():
     tmpdir = tempfile.mkdtemp()
 
@@ -333,3 +334,48 @@ def datafile_opener(open_func):
         raise NameError('open_func "{}" not recognized'.format(open_func))
 
 
+
+
+@pytest.yield_fixture
+def api_with_diverse_archives(mgr_name, fs_name):
+
+    with prep_manager(mgr_name) as manager:
+
+        api = DataAPI(
+            username='My Name',
+            contact='my.email@example.com')
+
+        api.attach_manager(manager)
+
+        with prep_filesystem(fs_name) as auth:
+
+            api.attach_authority('auth', auth1)
+
+            for indices in itertools.product(*(range(1,4) for _ in range(5))):
+                api.create(
+                    'team{}_project{}_task{}_variable{}_scenario{}.nc'.format(
+                        *indices))
+
+
+            for indices in itertools.product(*(range(1,4) for _ in range(5))):
+                api.create(
+                    'team{}_project{}_task{}_parameter{}_scenario{}.csv'.format(
+                        *indices))
+
+
+            for indices in itertools.product(*(range(1,4) for _ in range(3))):
+                api.create(
+                    'team{}_project{}_task{}_config.txt'.format(
+                        *indices))
+
+            api.TEST_ATTRS = {
+                'archives.variable': 243,
+                'archives.parameter': 243,
+                'archives.config': 27,
+                'count.variable': 3,
+                'count.parameter': 3,
+                'count.config': 1
+            }
+
+
+            yield api

--- a/tests/test_archive_search.py
+++ b/tests/test_archive_search.py
@@ -1,0 +1,99 @@
+
+def test_substr_search(api_with_diverse_archives):
+
+    # Test the total number of "variable" archives
+    variables = api_with_diverse_archives.list('_variable', engine='str')
+    assert len(variables) == api_with_diverse_archives.TEST_ATTRS[
+        'archives.variable']
+
+    # Test the total number of "variable1" archives
+    var1 = api_with_diverse_archives.list('_variable1_', engine='str')
+    assert len(var1) == (
+        api_with_diverse_archives.TEST_ATTRS['archives.variable'] / 
+        api_with_diverse_archives.TEST_ATTRS['count.variable'])
+
+
+    # Test the total number of "parameter" archives
+    parameters = api_with_diverse_archives.list('_parameter', engine='str')
+    assert len(parameters) == api_with_diverse_archives.TEST_ATTRS[
+        'archives.parameter']
+
+    # Test the total number of "parameter1" archives
+    var1 = api_with_diverse_archives.list('_parameter1_', engine='str')
+    assert len(var1) == (
+        api_with_diverse_archives.TEST_ATTRS['archives.parameter'] / 
+        api_with_diverse_archives.TEST_ATTRS['count.parameter'])
+
+
+    # Test the total number of "config" archives
+    config_files = api_with_diverse_archives.list('_config', engine='str')
+    assert len(config_files) == api_with_diverse_archives.TEST_ATTRS[
+        'archives.config']
+
+
+
+def test_regex_search(api_with_diverse_archives):
+
+    # Test the total number of "variable" archives
+    variables = api_with_diverse_archives.list(r'^.*_variable[0-9]+_.*$', engine='regex')
+    assert len(variables) == api_with_diverse_archives.TEST_ATTRS[
+        'archives.variable']
+
+    # Test the total number of "variable1" archives
+    var1 = api_with_diverse_archives.list(r'^.*_variable1_.*$', engine='regex')
+    assert len(var1) == (
+        api_with_diverse_archives.TEST_ATTRS['archives.variable'] / 
+        api_with_diverse_archives.TEST_ATTRS['count.variable'])
+
+
+    # Test the total number of "parameter" archives
+    parameters = api_with_diverse_archives.list(r'^.*_parameter[0-9]+_.*$', engine='regex')
+    assert len(parameters) == api_with_diverse_archives.TEST_ATTRS[
+        'archives.parameter']
+
+    # Test the total number of "parameter1" archives
+    var1 = api_with_diverse_archives.list(r'^.*_parameter1_.*$', engine='regex')
+    assert len(var1) == (
+        api_with_diverse_archives.TEST_ATTRS['archives.parameter'] / 
+        api_with_diverse_archives.TEST_ATTRS['count.parameter'])
+
+
+    # Test the total number of "config" archives
+    config_files = api_with_diverse_archives.list(r'^.*_config.*$', engine='regex')
+    assert len(config_files) == api_with_diverse_archives.TEST_ATTRS[
+        'archives.config']
+
+
+
+
+def test_fn_search(api_with_diverse_archives):
+
+    # Test the total number of "variable" archives
+    variables = api_with_diverse_archives.list('*_variable?*_*', engine='path')
+    assert len(variables) == api_with_diverse_archives.TEST_ATTRS[
+        'archives.variable']
+
+    # Test the total number of "variable1" archives
+    var1 = api_with_diverse_archives.list('*_variable1_*', engine='path')
+    assert len(var1) == (
+        api_with_diverse_archives.TEST_ATTRS['archives.variable'] / 
+        api_with_diverse_archives.TEST_ATTRS['count.variable'])
+
+
+    # Test the total number of "parameter" archives
+    parameters = api_with_diverse_archives.list('*_parameter?*_*', engine='path')
+    assert len(parameters) == api_with_diverse_archives.TEST_ATTRS[
+        'archives.parameter']
+
+    # Test the total number of "parameter1" archives
+    var1 = api_with_diverse_archives.list('*_parameter1_*', engine='path')
+    assert len(var1) == (
+        api_with_diverse_archives.TEST_ATTRS['archives.parameter'] / 
+        api_with_diverse_archives.TEST_ATTRS['count.parameter'])
+
+
+    # Test the total number of "config" archives
+    config_files = api_with_diverse_archives.list('*_config*', engine='path')
+    assert len(config_files) == api_with_diverse_archives.TEST_ATTRS[
+        'archives.config']
+


### PR DESCRIPTION
Addresses #105 

API changes:
* `DataAPI.list(self, substr=None)` --> `DataAPI.list(self, pattern=None, engine='path')`
  engine can be 'str', 'regex', or 'path' (default)
    - str: substring match (e.g. 'arc' in 'archive')
    - regex: regular expression search (`re.search(pattern, archive_name)`)
    - path: unix-style pathname match (`fnmatch.fnmatch(archive_name, pattern)`)

* `datafs list --substr "substr"` --> `datafs list --pattern "pattern" --engine "path"`