### PR TITLE
Tests for many archive apis

### DIFF
--- a/datafs/config/constructor.py
+++ b/datafs/config/constructor.py
@@ -72,8 +72,8 @@ class APIConstructor(object):
 
         >>> mgr = APIConstructor._generate_manager({
         ...     'class': 'DynamoDBManager',
-        ...     'args': ['data-from-yaml'],
         ...     'kwargs': {
+        ...         'table_name': 'data-from-yaml',
         ...         'session_args': {
         ...             'aws_access_key_id': "access-key-id-of-your-choice",
         ...             'aws_secret_access_key': "secret-key-of-your-choice"},
@@ -89,8 +89,8 @@ class APIConstructor(object):
         >>> 'data-from-yaml' in mgr.table_names
         False
         >>> mgr.create_archive_table('data-from-yaml')
-        >>> print(mgr.table_names[0])
-        data-from-yaml
+        >>> 'data-from-yaml' in mgr.table_names
+        True
         >>> mgr.delete_table('data-from-yaml')
 
         '''

--- a/datafs/core/data_api.py
+++ b/datafs/core/data_api.py
@@ -107,6 +107,7 @@ class DataAPI(object):
             versioned=True,
             raise_on_err=True,
             metadata=None,
+            tags=None,
             helper=False):
         '''
         Create a DataFS archive
@@ -155,6 +156,7 @@ class DataAPI(object):
             raise_on_err=raise_on_err,
             metadata=metadata,
             user_config=self.user_config,
+            tags=tags,
             helper=helper)
 
         return self._ArchiveConstructor(

--- a/datafs/managers/manager.py
+++ b/datafs/managers/manager.py
@@ -191,6 +191,7 @@ class BaseDataManager(object):
             raise_on_err=True,
             metadata=None,
             user_config=None,
+            tags=None,
             helper=False):
         '''
         Create a new data archive
@@ -210,6 +211,7 @@ class BaseDataManager(object):
             raise_on_err=raise_on_err,
             metadata=metadata,
             user_config=user_config,
+            tags=tags,
             helper=helper)
 
         if raise_on_err:
@@ -232,6 +234,7 @@ class BaseDataManager(object):
             raise_on_err=True,
             metadata=None,
             user_config=None,
+            tags=None,
             helper=False):
 
         if metadata is None:
@@ -239,6 +242,9 @@ class BaseDataManager(object):
 
         if user_config is None:
             user_config = {}
+
+        if tags is None:
+            tags = []
 
         check_requirements(
             to_populate=user_config,
@@ -257,7 +263,7 @@ class BaseDataManager(object):
             'versioned': versioned,
             'version_history': [],
             'archive_metadata': metadata,
-            'tags': []
+            'tags': tags
         }
         archive_metadata.update(user_config)
 

--- a/datafs/managers/manager.py
+++ b/datafs/managers/manager.py
@@ -68,13 +68,13 @@ class BaseDataManager(object):
 
         if raise_on_err:
             self._create_archive_table(table_name)
-            self._create_spec_table(table_name)
+            self._create_archive_table(table_name+'.spec')
             self._create_spec_config(table_name)
 
         else:
             try:
                 self._create_archive_table(table_name)
-                self._create_spec_table(table_name)
+                self._create_archive_table(table_name+'.spec')
                 self._create_spec_config(table_name)
             except KeyError:
                 pass
@@ -202,6 +202,38 @@ class BaseDataManager(object):
 
         '''
 
+        archive_metadata = self._create_archive_metadata(
+            archive_name=archive_name,
+            authority_name=authority_name,
+            archive_path=archive_path,
+            versioned=versioned,
+            raise_on_err=raise_on_err,
+            metadata=metadata,
+            user_config=user_config,
+            helper=helper)
+
+        if raise_on_err:
+            self._create_archive(
+                archive_name,
+                archive_metadata)
+        else:
+            self._create_if_not_exists(
+                archive_name,
+                archive_metadata)
+
+        return self.get_archive(archive_name)
+
+    def _create_archive_metadata(
+            self,
+            archive_name,
+            authority_name,
+            archive_path,
+            versioned,
+            raise_on_err=True,
+            metadata=None,
+            user_config=None,
+            helper=False):
+
         if metadata is None:
             metadata = {}
 
@@ -232,16 +264,7 @@ class BaseDataManager(object):
         archive_metadata['creation_date'] = archive_metadata.get(
             'creation_date', self.create_timestamp())
 
-        if raise_on_err:
-            self._create_archive(
-                archive_name,
-                archive_metadata)
-        else:
-            self._create_if_not_exists(
-                archive_name,
-                archive_metadata)
-
-        return self.get_archive(archive_name)
+        return archive_metadata
 
     def get_archive(self, archive_name):
         '''
@@ -470,10 +493,6 @@ class BaseDataManager(object):
             'BaseDataManager cannot be used directly. Use a subclass.')
 
     def _create_archive_table(self, table_name):
-        raise NotImplementedError(
-            'BaseDataManager cannot be used directly. Use a subclass.')
-
-    def _create_spec_table(self, table_name):
         raise NotImplementedError(
             'BaseDataManager cannot be used directly. Use a subclass.')
 

--- a/datafs/managers/manager_dynamo.py
+++ b/datafs/managers/manager_dynamo.py
@@ -158,49 +158,6 @@ class DynamoDBManager(BaseDataManager):
             msg = 'Table creation failed'
             assert table_name in self._get_table_names(), msg
 
-    def _create_spec_table(self, table_name):
-        '''
-        Dynamo implementation of User and Metadata Spec configuration
-
-        Called by `create_archive_table()` in
-        :py:class:`manager.BaseDataManager`. This table will additional table
-        will be aliased by 'table_name.spec'
-
-        A waiter is implemented on Dynamo to ensure table exists before
-        executing any subsequent operations
-
-        Paramters
-        ---------
-        table_name: str
-
-        Returns
-        -------
-        None
-        '''
-
-        spec_table = table_name + '.spec'
-
-        if spec_table in self._get_table_names():
-            raise KeyError('Table "{}" already exists'.format(spec_table))
-
-        try:
-            table = self._resource.create_table(
-                TableName=spec_table,
-                KeySchema=[
-                    {'AttributeName': '_id', 'KeyType': 'HASH'}],
-                AttributeDefinitions=[
-                    {'AttributeName': '_id', 'AttributeType': 'S'}],
-                ProvisionedThroughput={
-                    'ReadCapacityUnits': 123, 'WriteCapacityUnits': 123})
-
-            table.meta.client.get_waiter(
-                'table_exists').wait(TableName=spec_table)
-
-        except ValueError:
-            # Error handling for windows incompatability issue
-            msg = 'Table creation failed'
-            assert spec_table in self._get_table_names(), msg
-
     def _create_spec_config(self, table_name):
         '''
         Dynamo implementation of spec config creation

--- a/datafs/managers/manager_dynamo.py
+++ b/datafs/managers/manager_dynamo.py
@@ -31,14 +31,8 @@ class DynamoDBManager(BaseDataManager):
 
         super(DynamoDBManager, self).__init__(table_name)
 
-        if session_args is None:
-            session_args = {}
-
-        if resource_args is None:
-            resource_args = {}
-
-        self._session_args = session_args
-        self._resource_args = resource_args
+        self._session_args = {} if session_args is None else session_args
+        self._resource_args = {} if resource_args is None else resource_args
 
         self._session = boto3.Session(**session_args)
         self._resource = self._session.resource('dynamodb', **resource_args)
@@ -191,14 +185,11 @@ class DynamoDBManager(BaseDataManager):
         _spec_table.put_item(Item=user_config)
         _spec_table.put_item(Item=archive_config)
 
-    def _update_spec_config(self, document_name, spec=None):
+    def _update_spec_config(self, document_name, spec):
         '''
         Dynamo implementation of project specific metadata spec
 
         '''
-
-        if spec is None:
-            spec = {}
 
         spec_data_current = self._spec_table.get_item(
             Key={'_id': '{}'.format(document_name)})['Item']['config']

--- a/datafs/managers/manager_mongo.py
+++ b/datafs/managers/manager_mongo.py
@@ -214,7 +214,7 @@ class MongoDBManager(BaseDataManager):
 
 
         for r in res:
-            if (not begins_with) or r.startswith(begins_with):
+            if (not begins_with) or r['_id'].startswith(begins_with):
                 yield r['_id']
 
     def _set_tags(self, archive_name, updated_tag_list):

--- a/datafs/managers/manager_mongo.py
+++ b/datafs/managers/manager_mongo.py
@@ -210,38 +210,12 @@ class MongoDBManager(BaseDataManager):
             query = {
                 '$and': [{'tags': {'$in': [tag]}} for tag in search_terms]}
 
-        max_results = 50000
-        last_key = None
+        res = self.collection.find(query, {"_id": 1})
 
-        while True:
-            if last_key is None:
-                paged_query = query
 
-            else:
-                if len(query) > 0:
-                    paged_query = {'$and':
-                        query.get('$and', [query])
-                        + [{'_id': {'$gt': last_key}}]}
-
-                else:
-                    paged_query = {'_id': {'$gt': last_key}}
-
-            res = self.collection.find(
-                paged_query, {"_id": 1}).limit(max_results)
-
-            read = False
-
-            for r in res:
-
-                read = True
-
-                if (not begins_with) or r['_id'].startswith(begins_with):
-                    yield r['_id']
-
-            if not read:
-                break
-
-            last_key = r['_id']
+        for r in res:
+            if (not begins_with) or r.startswith(begins_with):
+                yield r['_id']
 
     def _set_tags(self, archive_name, updated_tag_list):
 

--- a/datafs/managers/manager_mongo.py
+++ b/datafs/managers/manager_mongo.py
@@ -212,7 +212,6 @@ class MongoDBManager(BaseDataManager):
 
         res = self.collection.find(query, {"_id": 1})
 
-
         for r in res:
             if (not begins_with) or r['_id'].startswith(begins_with):
                 yield r['_id']

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -363,7 +363,7 @@ def api_with_diverse_archives(request):
             contact='my.email@example.com')
 
         api.attach_manager(manager)
-        
+
         def direct_create_archive_spec(archive_name):
             return api.manager._create_archive_metadata(
                 archive_name=archive_name,
@@ -410,7 +410,7 @@ def api_with_diverse_archives(request):
                 archive_names.append(archive_name)
 
             batch_size = 500
-            
+
             for st_ind in range(0, len(archive_names), batch_size):
                 current_batch = archive_names[st_ind:st_ind+batch_size]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -373,7 +373,8 @@ def api_with_diverse_archives(request):
                 raise_on_err=True,
                 metadata={},
                 user_config={},
-                helper=False)
+                helper=False,
+                tags=os.path.splitext(archive_name)[0].split('_'))
 
         with prep_filesystem('OSFS') as auth1:
 

--- a/tests/test_archive_search.py
+++ b/tests/test_archive_search.py
@@ -12,6 +12,7 @@ def test_get_all_archives(api_with_diverse_archives):
 
     assert len(variables) == total
 
+
 def test_substr_search(api_with_diverse_archives):
 
     # Test the total number of "variable" archives
@@ -50,6 +51,7 @@ def test_substr_search(api_with_diverse_archives):
 
     assert len(config_files) == api_with_diverse_archives.TEST_ATTRS[
         'archives.config']
+
 
 def test_regex_search(api_with_diverse_archives):
 
@@ -198,7 +200,7 @@ def test_begins_with_filter_pattern(api_with_diverse_archives):
 
 
 def test_begins_with_tag_search(api_with_diverse_archives):
-    
+
     variables = list(
         api_with_diverse_archives.search(
             'variable2',
@@ -232,5 +234,3 @@ def test_begins_with_null_tag_search(api_with_diverse_archives):
             )
 
     assert len(variables) == 0
-
-

--- a/tests/test_archive_search.py
+++ b/tests/test_archive_search.py
@@ -1,3 +1,17 @@
+
+def test_get_all_archives(api_with_diverse_archives):
+
+    # Test the total number of archives
+    variables = list(
+        api_with_diverse_archives.filter())
+
+    total = (
+        api_with_diverse_archives.TEST_ATTRS['archives.variable']
+        + api_with_diverse_archives.TEST_ATTRS['archives.parameter']
+        + api_with_diverse_archives.TEST_ATTRS['archives.config'])
+
+    assert len(variables) == total
+
 def test_substr_search(api_with_diverse_archives):
 
     # Test the total number of "variable" archives

--- a/tests/test_archive_search.py
+++ b/tests/test_archive_search.py
@@ -51,7 +51,6 @@ def test_substr_search(api_with_diverse_archives):
     assert len(config_files) == api_with_diverse_archives.TEST_ATTRS[
         'archives.config']
 
-
 def test_regex_search(api_with_diverse_archives):
 
     # Test the total number of "variable" archives
@@ -174,3 +173,64 @@ def test_tagging_update_and_get(api_with_spec):
     result_delete = arch.get_tags()
     assert 'tag1' not in result_delete
     assert len(result_delete) == 2
+
+
+def test_begins_with_filter(api_with_diverse_archives):
+    variables = list(
+        api_with_diverse_archives.filter(
+            prefix='team1_project1_task1_var'))
+
+    assert len(variables) == (
+        api_with_diverse_archives.TEST_ATTRS['archives.variable']
+        / (api_with_diverse_archives.TEST_ATTRS['count.variable'] ** 3))
+
+
+def test_begins_with_filter_pattern(api_with_diverse_archives):
+    variables = list(
+        api_with_diverse_archives.filter(
+            prefix='team1_project1_task1_var',
+            pattern='*_scenario1.nc',
+            engine='path'))
+
+    assert len(variables) == (
+        api_with_diverse_archives.TEST_ATTRS['archives.variable']
+        / (api_with_diverse_archives.TEST_ATTRS['count.variable'] ** 4))
+
+
+def test_begins_with_tag_search(api_with_diverse_archives):
+    
+    variables = list(
+        api_with_diverse_archives.search(
+            'variable2',
+            prefix='team1_project1_task1_var')
+            )
+
+    assert len(variables) == (
+        api_with_diverse_archives.TEST_ATTRS['archives.variable']
+        / (api_with_diverse_archives.TEST_ATTRS['count.variable'] ** 4))
+
+    variables = list(
+        api_with_diverse_archives.search(
+            'variable2',
+            'scenario2',
+            'team1',
+            prefix='team1_project1_task1_var')
+            )
+
+    assert len(variables) == (
+        api_with_diverse_archives.TEST_ATTRS['archives.variable']
+        / (api_with_diverse_archives.TEST_ATTRS['count.variable'] ** 5))
+
+
+def test_begins_with_null_tag_search(api_with_diverse_archives):
+
+    variables = list(
+        api_with_diverse_archives.search(
+            'parameter1',
+            'team1',
+            prefix='team1_project1_task1_var')
+            )
+
+    assert len(variables) == 0
+
+

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -178,11 +178,6 @@ def test_create_archive_table(base_manager):
         base_manager._create_archive_table('table_name')
 
 
-def test_create_spec_table(base_manager):
-    with pytest.raises(NotImplementedError):
-        base_manager._create_spec_table('table_name')
-
-
 def test_create_spec_config(base_manager):
     with pytest.raises(NotImplementedError):
         base_manager._create_spec_config('table_name')


### PR DESCRIPTION
In this PR:
* Add tests for search and filter queries on very large manager tables
* Allow tag specification on create
* Restructure conftest.py: api_with_diverse_archives to be session-scoped
* Improve test coverage
* Move archive document creation to separate method in manager (allows batch write in tests)
* Consolidate `manager._create_archive_table` and `_create_spec_table` into one function