### PR TITLE
fix bug in docs build

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,3 +1,6 @@
+click==6.7
+PyYAML==3.12
+fs==0.5.5a1
 pip==9.0.1
 wheel==0.29.0
 flake8==3.3.0


### PR DESCRIPTION
readthedocs needs a full set of requirements in reaquirements_dev.txt in order to build. Added requirements from requirements.txt