### PR TITLE
Staging

### DIFF
--- a/datafs/__init__.py
+++ b/datafs/__init__.py
@@ -8,7 +8,7 @@ from datafs.config.helpers import get_api, to_config_file
 
 __author__ = """Climate Impact Lab"""
 __email__ = 'jsimcock@rhg.com'
-__version__ = '0.6.7'
+__version__ = '0.6.8'
 
 _module_imports = (
     DataAPI,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.6.7
+current_version = 0.6.8
 commit = True
 tag = True
 
@@ -19,4 +19,5 @@ exclude = docs
 
 [aliases]
 addopts = ./datafs ./tests ./docs --cov=datafs --cov=examples --cov=docs --doctest-modules --cov-report term-missing
-test = pytest 
+test = pytest
+

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ entry_points = '[console_scripts]\ndatafs=datafs.datafs:cli'
 
 setup(
     name='datafs',
-    version='0.6.7',
+    version='0.6.8',
     description=description,
     long_description=readme + '\n\n' + history,
     author="Climate Impact Lab",


### PR DESCRIPTION
Oops. The docs won't build because we need the full set of requirements to be in `requirements_dev.txt`, which is where readthedocs gets DataFS's dependencies.

This build adds required dependencies to `requirements_dev.txt`