### PR TITLE
Slasher

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
     - DATAFS_TEST_ENV=xarray
 
 matrix:
-  allow_failures:
+  exclude:
     - python: pypy
       env: DATAFS_TEST_ENV=xarray
 

--- a/datafs/core/data_api.py
+++ b/datafs/core/data_api.py
@@ -253,8 +253,7 @@ class DataAPI(object):
 
         return self.manager.search(query, begins_with=prefix)
 
-    @classmethod
-    def validate_archive_path(cls, archive_name):
+    def validate_archive_path(self, archive_name):
         '''
         Utility function for creating and validating internal service paths
 
@@ -269,19 +268,12 @@ class DataAPI(object):
 
         archive_path : str
             Internal path used by services to reference archive data
-
-        Default: split archive name on underscores
-
-        Example
-        -------
-
-        .. code-block:: python
-
-            >>> print(DataAPI.validate_archive_path(
-            ...     'pictures_2016_may_vegas_wedding.png'))
-            pictures/2016/may/vegas/wedding.png
-
         '''
+        patterns = self.manager.required_archive_patterns
+        
+        for pattern in patterns:
+            assert re.search(pattern, archive_name), AssertionError("archive name does not match pattern '{}'".format(pattern))
+
         return archive_name
 
     def delete_archive(self, archive_name):

--- a/datafs/core/data_api.py
+++ b/datafs/core/data_api.py
@@ -100,7 +100,6 @@ class DataAPI(object):
             self,
             archive_name,
             authority_name=None,
-            archive_path=None,
             versioned=True,
             raise_on_err=True,
             metadata=None,
@@ -117,9 +116,6 @@ class DataAPI(object):
 
         authority_name : str
             Name of the data service to use as the archive's data authority
-
-        archive_path : str
-            Path to use on the data services (optional)
 
         versioned : bool
             If true, store all versions with explicit version numbers (defualt)
@@ -142,8 +138,7 @@ class DataAPI(object):
         if authority_name not in self._authorities:
             raise KeyError('Authority "{}" not found'.format(authority_name))
 
-        if archive_path is None:
-            archive_path = self.validate_archive_path(archive_name)
+        self._validate_archive_name(archive_name)
 
         if metadata is None:
             metadata = {}
@@ -151,7 +146,7 @@ class DataAPI(object):
         res = self.manager.create_archive(
             archive_name,
             authority_name,
-            archive_path=archive_path,
+            archive_path=archive_name,
             versioned=versioned,
             raise_on_err=raise_on_err,
             metadata=metadata,
@@ -253,9 +248,9 @@ class DataAPI(object):
 
         return self.manager.search(query, begins_with=prefix)
 
-    def validate_archive_path(self, archive_name):
+    def _validate_archive_name(self, archive_name):
         '''
-        Utility function for creating and validating internal service paths
+        Utility function for creating and validating archive names
 
         Parameters
         ----------
@@ -270,11 +265,11 @@ class DataAPI(object):
             Internal path used by services to reference archive data
         '''
         patterns = self.manager.required_archive_patterns
-        
-        for pattern in patterns:
-            assert re.search(pattern, archive_name), AssertionError("archive name does not match pattern '{}'".format(pattern))
 
-        return archive_name
+        for pattern in patterns:
+            if not re.search(pattern, archive_name):
+                raise ValueError(
+                    "archive name does not match pattern '{}'".format(pattern))
 
     def delete_archive(self, archive_name):
         '''

--- a/datafs/core/data_api.py
+++ b/datafs/core/data_api.py
@@ -143,7 +143,7 @@ class DataAPI(object):
             raise KeyError('Authority "{}" not found'.format(authority_name))
 
         if archive_path is None:
-            archive_path = self.create_archive_path(archive_name)
+            archive_path = self.validate_archive_path(archive_name)
 
         if metadata is None:
             metadata = {}
@@ -254,9 +254,9 @@ class DataAPI(object):
         return self.manager.search(query, begins_with=prefix)
 
     @classmethod
-    def create_archive_path(cls, archive_name):
+    def validate_archive_path(cls, archive_name):
         '''
-        Utility function for creating and checking internal service paths
+        Utility function for creating and validating internal service paths
 
         Parameters
         ----------
@@ -277,12 +277,11 @@ class DataAPI(object):
 
         .. code-block:: python
 
-            >>> print(DataAPI.create_archive_path(
+            >>> print(DataAPI.validate_archive_path(
             ...     'pictures_2016_may_vegas_wedding.png'))
             pictures/2016/may/vegas/wedding.png
 
         '''
-
         return archive_name
 
     def delete_archive(self, archive_name):

--- a/datafs/core/data_api.py
+++ b/datafs/core/data_api.py
@@ -4,9 +4,6 @@ from datafs.services.service import DataService
 from datafs.core.data_archive import DataArchive
 from datafs._compat import open_filelike
 
-
-import fs.path
-
 import hashlib
 import fnmatch
 import re
@@ -284,31 +281,9 @@ class DataAPI(object):
             ...     'pictures_2016_may_vegas_wedding.png'))
             pictures/2016/may/vegas/wedding.png
 
-        *Overloading*
-
-        Overload this function to change default internal service path format
-        and to enforce certain requirements on paths:
-
-        .. code-block:: python
-
-            >>> class MyAPI(DataAPI):
-            ...     @classmethod
-            ...     def create_archive_path(cls, archive_name):
-            ...         if '_' in archive_name:
-            ...             raise ValueError('No underscores allowed!')
-            ...         return archive_name
-            ...
-            >>> api = MyAPI
-            >>> api.create_archive_path(
-            ...   'pictures_2016_may_vegas_wedding.png')   # doctest: +ELLIPSIS
-            Traceback (most recent call last):
-            ...
-            ValueError: No underscores allowed!
-
-
         '''
 
-        return fs.path.join(*tuple(archive_name.split('_')))
+        return archive_name
 
     def delete_archive(self, archive_name):
         '''

--- a/datafs/managers/manager.py
+++ b/datafs/managers/manager.py
@@ -21,6 +21,8 @@ class BaseDataManager(object):
 
         self._required_user_config = None
         self._required_archive_metadata = None
+        self._valid_top_level_domains = None
+        self._required_archive_patterns = None
 
     @property
     def table_names(self):
@@ -41,13 +43,6 @@ class BaseDataManager(object):
         return self._required_archive_metadata
 
     @property
-    def valid_top_level_domains(self):
-        if self._valid_top_level_domains is None:
-            self._refresh_spec()
-
-        return self._valid_top_level_domains
-
-    @property
     def required_archive_patterns(self):
         if self._required_archive_patterns is None:
             self._refresh_spec()
@@ -61,7 +56,6 @@ class BaseDataManager(object):
 
         self._required_user_config = spec['required_user_config']
         self._required_archive_metadata = spec['required_archive_metadata']
-        self._valid_top_level_domains = spec['valid_top_level_domains']
         self._required_archive_patterns = spec['required_archive_patterns']
 
     def create_archive_table(self, table_name, raise_on_err=True):
@@ -85,7 +79,6 @@ class BaseDataManager(object):
         spec_documents = [
             {'_id': 'required_user_config', 'config': {}},
             {'_id': 'required_archive_metadata', 'config': {}},
-            {'_id': 'valid_top_level_domains', 'config': None},
             {'_id': 'required_archive_patterns', 'config': []}]
 
         if raise_on_err:
@@ -163,6 +156,19 @@ class BaseDataManager(object):
 
         self.update_spec_config('required_archive_metadata', metadata_config)
         self._required_archive_metadata = None
+
+    def set_required_archive_patterns(self, required_archive_patterns):
+        '''
+        Sets archive_name regex patterns for the enforcement of naming
+        conventions on archive creation
+
+        Parameters
+        ----------
+        required_archive_patterns: strings  of args
+        '''
+        self.update_spec_config('required_archive_patterns',
+                                required_archive_patterns)
+        self._required_archive_patterns = None
 
     def delete_table(self, table_name=None, raise_on_err=True):
         if table_name is None:

--- a/datafs/managers/manager.py
+++ b/datafs/managers/manager.py
@@ -537,7 +537,7 @@ class BaseDataManager(object):
         raise NotImplementedError(
             'BaseDataManager cannot be used directly. Use a subclass.')
 
-    def _create_spec_config(self, table_name):
+    def _create_spec_config(self, table_name, spec_documents):
         raise NotImplementedError(
             'BaseDataManager cannot be used directly. Use a subclass.')
 

--- a/datafs/managers/manager.py
+++ b/datafs/managers/manager.py
@@ -40,6 +40,20 @@ class BaseDataManager(object):
 
         return self._required_archive_metadata
 
+    @property
+    def valid_top_level_domains(self):
+        if self._valid_top_level_domains is None:
+            self._refresh_spec()
+
+        return self._valid_top_level_domains
+
+    @property
+    def required_archive_patterns(self):
+        if self._required_archive_patterns is None:
+            self._refresh_spec()
+
+        return self._required_archive_patterns
+
     def _refresh_spec(self):
         spec_documents = self._get_spec_documents(self._table_name)
 
@@ -47,6 +61,8 @@ class BaseDataManager(object):
 
         self._required_user_config = spec['required_user_config']
         self._required_archive_metadata = spec['required_archive_metadata']
+        self._valid_top_level_domains = spec['valid_top_level_domains']
+        self._required_archive_patterns = spec['required_archive_patterns']
 
     def create_archive_table(self, table_name, raise_on_err=True):
         '''
@@ -68,7 +84,9 @@ class BaseDataManager(object):
 
         spec_documents = [
             {'_id': 'required_user_config', 'config': {}},
-            {'_id': 'required_archive_metadata', 'config': {}}]
+            {'_id': 'required_archive_metadata', 'config': {}},
+            {'_id': 'valid_top_level_domains', 'config': None},
+            {'_id': 'required_archive_patterns', 'config': []}]
 
         if raise_on_err:
             self._create_archive_table(table_name)

--- a/datafs/managers/manager.py
+++ b/datafs/managers/manager.py
@@ -66,16 +66,20 @@ class BaseDataManager(object):
 
         '''
 
+        spec_documents = [
+            {'_id': 'required_user_config', 'config': {}},
+            {'_id': 'required_archive_metadata', 'config': {}}]
+
         if raise_on_err:
             self._create_archive_table(table_name)
             self._create_archive_table(table_name+'.spec')
-            self._create_spec_config(table_name)
+            self._create_spec_config(table_name, spec_documents)
 
         else:
             try:
                 self._create_archive_table(table_name)
                 self._create_archive_table(table_name+'.spec')
-                self._create_spec_config(table_name)
+                self._create_spec_config(table_name, spec_documents)
             except KeyError:
                 pass
 

--- a/datafs/managers/manager_dynamo.py
+++ b/datafs/managers/manager_dynamo.py
@@ -180,17 +180,11 @@ class DynamoDBManager(BaseDataManager):
         Dynamo implementation of project specific metadata spec
 
         '''
-
-        spec_data_current = self._spec_table.get_item(
-            Key={'_id': '{}'.format(document_name)})['Item']['config']
-
-        spec_data_current.update(spec)
-
         # add the updated archive_metadata object to Dynamo
         self._spec_table.update_item(
             Key={'_id': '{}'.format(document_name)},
             UpdateExpression="SET config = :v",
-            ExpressionAttributeValues={':v': spec_data_current},
+            ExpressionAttributeValues={':v': spec},
             ReturnValues='ALL_NEW')
 
     def _delete_table(self, table_name):

--- a/datafs/managers/manager_dynamo.py
+++ b/datafs/managers/manager_dynamo.py
@@ -162,11 +162,15 @@ class DynamoDBManager(BaseDataManager):
 
         Parameters
         ----------
-        table_name
 
-        Returns
-        -------
-        None
+        table_name :
+
+            base table name (not including .spec suffix)
+
+        spec_documents : list
+
+            list of dictionary documents defining the manager spec
+
 
         '''
 
@@ -204,13 +208,13 @@ class DynamoDBManager(BaseDataManager):
         Parameters
         ----------
         archive_name: str
-            Unique GCP_ID archive name
+
+            ID of archive to update
 
         updated_metadata: dict
-            Dictionary of update metadata values
-            Right now just lets you append anything to the list
 
-        .. todo::
+            dictionary of metadata keys and values to update. If the value
+            for a particular key is `None`, the key is removed.
 
         """
 
@@ -244,13 +248,6 @@ class DynamoDBManager(BaseDataManager):
         -------
         Dictionary with confirmation of upload
 
-        Note
-        ----
-        versioning is handled by s3
-
-        Todo
-        -----
-        Coerce underscores to dashes
         '''
 
         archive_exists = False

--- a/datafs/managers/manager_dynamo.py
+++ b/datafs/managers/manager_dynamo.py
@@ -220,14 +220,6 @@ class DynamoDBManager(BaseDataManager):
 
         """
 
-        required_metadata_keys = self._get_required_archive_metadata().keys()
-
-        for k, v in archive_metadata.items():
-            if k in required_metadata_keys and v is None:
-                raise ValueError(
-                    'Value for key {} is None. '.format(k) +
-                    'None cannot be a value for required metadata')
-
         archive_metadata_current = self._get_archive_metadata(archive_name)
         archive_metadata_current.update(archive_metadata)
         for k, v in archive_metadata_current.items():
@@ -291,16 +283,6 @@ class DynamoDBManager(BaseDataManager):
             DynamoDB specific results - do not expose to user
         '''
         return self._table.get_item(Key={'_id': archive_name})['Item']
-
-    def _get_required_user_config(self):
-
-        return self._spec_table.get_item(Key={
-            '_id': '{}'.format('required_user_config')})['Item']['config']
-
-    def _get_required_archive_metadata(self):
-
-        return self._spec_table.get_item(Key={
-            '_id': '{}'.format('required_archive_metadata')})['Item']['config']
 
     def _delete_archive_record(self, archive_name):
 

--- a/datafs/managers/manager_dynamo.py
+++ b/datafs/managers/manager_dynamo.py
@@ -152,7 +152,7 @@ class DynamoDBManager(BaseDataManager):
             msg = 'Table creation failed'
             assert table_name in self._get_table_names(), msg
 
-    def _create_spec_config(self, table_name):
+    def _create_spec_config(self, table_name, spec_documents):
         '''
         Dynamo implementation of spec config creation
 
@@ -172,18 +172,8 @@ class DynamoDBManager(BaseDataManager):
 
         _spec_table = self._resource.Table(table_name + '.spec')
 
-        user_config = {
-            '_id': 'required_user_config',
-            'config': {}
-        }
-
-        archive_config = {
-            '_id': 'required_archive_metadata',
-            'config': {}
-        }
-
-        _spec_table.put_item(Item=user_config)
-        _spec_table.put_item(Item=archive_config)
+        for doc in spec_documents:
+            _spec_table.put_item(Item=doc)
 
     def _update_spec_config(self, document_name, spec):
         '''

--- a/datafs/managers/manager_mongo.py
+++ b/datafs/managers/manager_mongo.py
@@ -4,30 +4,7 @@ from __future__ import absolute_import
 from datafs.managers.manager import BaseDataManager
 
 from pymongo import MongoClient
-from pymongo.errors import ServerSelectionTimeoutError, DuplicateKeyError
-
-
-class ConnectionError(IOError):
-    pass
-
-
-def catch_timeout(func):
-    '''
-    Decorator for wrapping MongoDB connections
-    '''
-
-    def inner(*args, **kwargs):
-        msg = 'Connection to MongoDB server could not be established. '\
-            'Make sure you are running a MongoDB server and that the MongoDB '\
-            'Manager has been configured to connect over the correct port. '\
-            'For more information see '\
-            'https://docs.mongodb.com/manual/tutorial/.'
-        try:
-            return func(*args, **kwargs)
-        except ServerSelectionTimeoutError:
-            raise ConnectionError(msg)
-
-    return inner
+from pymongo.errors import DuplicateKeyError
 
 
 class MongoDBManager(BaseDataManager):
@@ -81,7 +58,6 @@ class MongoDBManager(BaseDataManager):
     def table_name(self):
         return self._table_name
 
-    @catch_timeout
     def _get_table_names(self):
         return self.db.collection_names(include_system_collections=False)
 
@@ -125,7 +101,6 @@ class MongoDBManager(BaseDataManager):
 
     # Private methods (to be implemented!)
 
-    @catch_timeout
     def _update(self, archive_name, version_metadata):
         self.collection.update(
             {"_id": archive_name},
@@ -151,7 +126,6 @@ class MongoDBManager(BaseDataManager):
             {"_id": document_name},
             {"$set": {'config': spec}}, upsert=True)
 
-    @catch_timeout
     def _create_archive(
             self,
             archive_name,
@@ -162,7 +136,6 @@ class MongoDBManager(BaseDataManager):
         except DuplicateKeyError:
             raise KeyError('Archive "{}" already exists'.format(archive_name))
 
-    @catch_timeout
     def _create_spec_config(self, table_name, spec_documents):
 
         if self._spec_coll is None:
@@ -170,7 +143,6 @@ class MongoDBManager(BaseDataManager):
 
         self.spec_collection.insert_many(spec_documents)
 
-    @catch_timeout
     def _get_archive_listing(self, archive_name):
         '''
         Return full document for ``{_id:'archive_name'}``

--- a/datafs/managers/manager_mongo.py
+++ b/datafs/managers/manager_mongo.py
@@ -133,14 +133,9 @@ class MongoDBManager(BaseDataManager):
 
     def _update_metadata(self, archive_name, archive_metadata):
 
-        required_metadata_keys = self._get_required_archive_metadata().keys()
         for key, val in archive_metadata.items():
-            if key in required_metadata_keys and val is None:
-                raise ValueError(
-                    'Value for key {} is None. '.format(key) +
-                    'None cannot be a value for required metadata')
 
-            elif val is None:
+            if val is None:
                 self.collection.update(
                     {"_id": archive_name},
                     {"$unset": {"archive_metadata.{}".format(key): ""}})
@@ -220,13 +215,3 @@ class MongoDBManager(BaseDataManager):
 
     def _get_spec_documents(self, table_name):
         return [item for item in self.spec_collection.find({})]
-
-    def _get_required_user_config(self):
-
-        return self.spec_collection.find_one(
-            {'_id': 'required_user_config'})['config']
-
-    def _get_required_archive_metadata(self):
-
-        return self.spec_collection.find_one(
-            {'_id': 'required_archive_metadata'})['config']

--- a/datafs/managers/manager_mongo.py
+++ b/datafs/managers/manager_mongo.py
@@ -168,16 +168,12 @@ class MongoDBManager(BaseDataManager):
             raise KeyError('Archive "{}" already exists'.format(archive_name))
 
     @catch_timeout
-    def _create_spec_config(self, table_name):
+    def _create_spec_config(self, table_name, spec_documents):
 
         if self._spec_coll is None:
             self._spec_coll = self.db[table_name + '.spec']
 
-        itrbl = [
-            {'_id': x, 'config': {}}
-            for x in ('required_user_config', 'required_archive_metadata')]
-
-        self.spec_collection.insert_many(itrbl)
+        self.spec_collection.insert_many(spec_documents)
 
     @catch_timeout
     def _get_archive_listing(self, archive_name):

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,3 +39,6 @@ History
 =======
 
 DataFS was developed for use by the `Climate Impact Lab <http://impactlab.org>`_. Check us out on `github <https://github.com/ClimateImpactLab>`_.
+
+.. meta::
+   :description: DataFS Data Management System Documentation

--- a/examples/caching.py
+++ b/examples/caching.py
@@ -37,7 +37,7 @@ For this example we'll use an AWS S3 store. Any filesystem will work, though:
 Create an archive
 
     >>> var = api.create(
-    ...     'caching_archive',
+    ...     'caching/archive.txt',
     ...     metadata = dict(description = 'My cached remote archive'),
     ...     authority_name='aws')
     >>>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -273,6 +273,7 @@ def manager_with_pattern(mgr_name):
 
         yield manager
 
+
 @pytest.yield_fixture
 def api_with_spec(manager_with_spec, auth1):
 
@@ -284,6 +285,7 @@ def api_with_spec(manager_with_spec, auth1):
     api.attach_authority('auth', auth1)
 
     yield api
+
 
 @pytest.yield_fixture
 def api_with_pattern(manager_with_pattern, auth1):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -266,13 +266,24 @@ def manager_with_pattern(mgr_name):
 
         }
 
-        archive_name_patterns = ['string1', 'string2', 'string3', 'string4']
+        GCP_PATTERNS = [r'^(TLD1/(sub1|sub2|sub3)|TLD2/(sub1|sub2|sub3))']
         manager.set_required_user_config(user_config)
         manager.set_required_archive_metadata(metadata_config)
-        manager.set_required_archive_patterns(archive_name_patterns)
+        manager.set_required_archive_patterns(GCP_PATTERNS)
 
         yield manager
 
+@pytest.yield_fixture
+def api_with_spec(manager_with_spec, auth1):
+
+    api = DataAPI(
+        username='My Name',
+        contact='my.email@example.com')
+
+    api.attach_manager(manager_with_spec)
+    api.attach_authority('auth', auth1)
+
+    yield api
 
 @pytest.yield_fixture
 def api_with_pattern(manager_with_pattern, auth1):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -382,7 +382,7 @@ def api_with_diverse_archives(request):
     PARS = 5
     CONF = 3
 
-    with prep_manager(request.param) as manager:
+    with prep_manager(request.param, table_name='diverse') as manager:
 
         api = DataAPI(
             username='My Name',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -233,7 +233,7 @@ def cache2():
 @pytest.yield_fixture
 def manager_with_spec(mgr_name):
 
-    with prep_manager(mgr_name, table_name='standalone-test-table') as manager:
+    with prep_manager(mgr_name, table_name='spec-test') as manager:
 
         metadata_config = {
             'description': 'some metadata'
@@ -254,21 +254,9 @@ def manager_with_spec(mgr_name):
 @pytest.yield_fixture
 def manager_with_pattern(mgr_name):
 
-    with prep_manager(mgr_name, table_name='standalone-test-table') as manager:
-
-        metadata_config = {
-            'description': 'some metadata'
-        }
-
-        user_config = {
-            'username': 'Your Name',
-            'contact': 'my.email@example.com'
-
-        }
+    with prep_manager(mgr_name, table_name='pattern-test') as manager:
 
         GCP_PATTERNS = [r'^(TLD1/(sub1|sub2|sub3)|TLD2/(sub1|sub2|sub3))']
-        manager.set_required_user_config(user_config)
-        manager.set_required_archive_metadata(metadata_config)
         manager.set_required_archive_patterns(GCP_PATTERNS)
 
         yield manager
@@ -290,9 +278,7 @@ def api_with_spec(manager_with_spec, auth1):
 @pytest.yield_fixture
 def api_with_pattern(manager_with_pattern, auth1):
 
-    api = DataAPI(
-        username='My Name',
-        contact='my.email@example.com')
+    api = DataAPI()
 
     api.attach_manager(manager_with_pattern)
     api.attach_authority('auth', auth1)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -252,13 +252,36 @@ def manager_with_spec(mgr_name):
 
 
 @pytest.yield_fixture
-def api_with_spec(manager_with_spec, auth1):
+def manager_with_pattern(mgr_name):
+
+    with prep_manager(mgr_name, table_name='standalone-test-table') as manager:
+
+        metadata_config = {
+            'description': 'some metadata'
+        }
+
+        user_config = {
+            'username': 'Your Name',
+            'contact': 'my.email@example.com'
+
+        }
+
+        archive_name_patterns = ['string1', 'string2', 'string3', 'string4']
+        manager.set_required_user_config(user_config)
+        manager.set_required_archive_metadata(metadata_config)
+        manager.set_required_archive_patterns(archive_name_patterns)
+
+        yield manager
+
+
+@pytest.yield_fixture
+def api_with_pattern(manager_with_pattern, auth1):
 
     api = DataAPI(
         username='My Name',
         contact='my.email@example.com')
 
-    api.attach_manager(manager_with_spec)
+    api.attach_manager(manager_with_pattern)
     api.attach_authority('auth', auth1)
 
     yield api

--- a/tests/test_archive_name_pattern.py
+++ b/tests/test_archive_name_pattern.py
@@ -1,12 +1,28 @@
 import pytest
 
-
 @pytest.mark.pattern
 def test_required_archive_patterns(api_with_pattern):
 
-    assert api_with_pattern.manager.required_archive_patterns == \
-	                        ['string1', 'string2', 'string3', 'string4']
-	api_with_pattern.create('string1/string2/string3',
-		                     metadata=dict(description='some description'))
+    assert api_with_pattern.manager.required_archive_patterns == [r'^(TLD1/(sub1|sub2|sub3)|TLD2/(sub1|sub2|sub3))']
+    archive = api_with_pattern.create('TLD1/sub1/substring1/substring1a.csv',
+		                    metadata=dict(description='some description'))
 
-	
+    assert archive.archive_name == 'TLD1/sub1/substring1/substring1a.csv'
+
+    archive2 = api_with_pattern.create('TLD2/sub2/substring1/substring1a.csv',
+		                    metadata=dict(description='some description'))
+
+    assert archive2.archive_name == 'TLD2/sub2/substring1/substring1a.csv'
+
+    archive3 = api_with_pattern.create('TLD2/sub3/substring1/substring1a.csv',
+		                    metadata=dict(description='some description'))
+
+    assert archive3.archive_name == 'TLD2/sub3/substring1/substring1a.csv'
+
+    with pytest.raises(AssertionError):
+    	api_with_pattern.create('SOME/string1/string2/string3.csv',
+    						metadata=dict(description='some description'))
+
+    with pytest.raises(AssertionError):
+    	api_with_pattern.create('TLD1_sub1_substring1.txt', metadata=dict(description='some description'))
+

--- a/tests/test_archive_name_pattern.py
+++ b/tests/test_archive_name_pattern.py
@@ -1,28 +1,36 @@
 import pytest
 
+
 @pytest.mark.pattern
 def test_required_archive_patterns(api_with_pattern):
 
-    assert api_with_pattern.manager.required_archive_patterns == [r'^(TLD1/(sub1|sub2|sub3)|TLD2/(sub1|sub2|sub3))']
-    archive = api_with_pattern.create('TLD1/sub1/substring1/substring1a.csv',
-		                    metadata=dict(description='some description'))
+    assert api_with_pattern.manager.required_archive_patterns == [
+            r'^(TLD1/(sub1|sub2|sub3)|TLD2/(sub1|sub2|sub3))']
+
+    archive = api_with_pattern.create(
+        'TLD1/sub1/substring1/substring1a.csv',
+        metadata=dict(description='some description'))
 
     assert archive.archive_name == 'TLD1/sub1/substring1/substring1a.csv'
 
-    archive2 = api_with_pattern.create('TLD2/sub2/substring1/substring1a.csv',
-		                    metadata=dict(description='some description'))
+    archive2 = api_with_pattern.create(
+        'TLD2/sub2/substring1/substring1a.csv',
+        metadata=dict(description='some description'))
 
     assert archive2.archive_name == 'TLD2/sub2/substring1/substring1a.csv'
 
-    archive3 = api_with_pattern.create('TLD2/sub3/substring1/substring1a.csv',
-		                    metadata=dict(description='some description'))
+    archive3 = api_with_pattern.create(
+        'TLD2/sub3/substring1/substring1a.csv',
+        metadata=dict(description='some description'))
 
     assert archive3.archive_name == 'TLD2/sub3/substring1/substring1a.csv'
 
-    with pytest.raises(AssertionError):
-    	api_with_pattern.create('SOME/string1/string2/string3.csv',
-    						metadata=dict(description='some description'))
+    with pytest.raises(ValueError):
+        api_with_pattern.create(
+            'SOME/string1/string2/string3.csv',
+            metadata=dict(description='some description'))
 
-    with pytest.raises(AssertionError):
-    	api_with_pattern.create('TLD1_sub1_substring1.txt', metadata=dict(description='some description'))
-
+    with pytest.raises(ValueError):
+        api_with_pattern.create(
+            'TLD1_sub1_substring1.txt',
+            metadata=dict(description='some description'))

--- a/tests/test_archive_name_pattern.py
+++ b/tests/test_archive_name_pattern.py
@@ -1,0 +1,12 @@
+import pytest
+
+
+@pytest.mark.pattern
+def test_required_archive_patterns(api_with_pattern):
+
+    assert api_with_pattern.manager.required_archive_patterns == \
+	                        ['string1', 'string2', 'string3', 'string4']
+	api_with_pattern.create('string1/string2/string3',
+		                     metadata=dict(description='some description'))
+
+	

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -20,7 +20,7 @@ def test_spec_table_creation(manager_with_spec):
 def test_spec_config_creation(manager_with_spec):
 
     assert len(manager_with_spec._get_spec_documents(
-        'standalone-test-table')) == 4
+        'standalone-test-table')) == 3
 
 
 def test_spec_config_update_metadata(manager_with_spec):

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -196,16 +196,6 @@ def test_delete_table(base_manager):
         base_manager._delete_table('table_name')
 
 
-def test_get_required_user_config(base_manager):
-    with pytest.raises(NotImplementedError):
-        base_manager._get_required_user_config()
-
-
-def test_get_required_archive_metadata(base_manager):
-    with pytest.raises(NotImplementedError):
-        base_manager._get_required_archive_metadata()
-
-
 def test_get_version_history(base_manager):
     with pytest.raises(NotImplementedError):
         base_manager._get_version_history('archive_name')

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -20,7 +20,7 @@ def test_spec_table_creation(manager_with_spec):
 def test_spec_config_creation(manager_with_spec):
 
     assert len(manager_with_spec._get_spec_documents(
-        'standalone-test-table')) == 2
+        'standalone-test-table')) == 4
 
 
 def test_spec_config_update_metadata(manager_with_spec):

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -118,72 +118,72 @@ def test_manager_spec_setup_api_metadata(api_with_spec, auth1):
         api_with_spec.create('my_api_test_archive', metadata={})
 
 
-def test_update(base_manager):
+def test_base_manager_update(base_manager):
     with pytest.raises(NotImplementedError):
         base_manager._update('archive_name', {})
 
 
-def test_create_archive(base_manager):
+def test_base_manager_create_archive(base_manager):
     with pytest.raises(NotImplementedError):
         base_manager._create_archive('archive_name', {})
 
 
-def test_create_if_not_exists(base_manager):
+def test_base_manager_create_if_not_exists(base_manager):
     with pytest.raises(NotImplementedError):
         base_manager._create_if_not_exists('archive_name', {})
 
 
-def test_get_archives(base_manager):
+def test_base_manager_get_archives(base_manager):
     with pytest.raises(NotImplementedError):
         base_manager._get_archives()
 
 
-def test_get_archive_listing(base_manager):
+def test_base_manager_get_archive_listing(base_manager):
     with pytest.raises(NotImplementedError):
         base_manager._get_archive_listing('archive_name')
 
 
-def test_get_archive_metadata(base_manager):
+def test_base_manager_get_archive_metadata(base_manager):
     with pytest.raises(NotImplementedError):
         base_manager._get_archive_metadata('archive_name')
 
 
-def test_get_latest_hash(base_manager):
+def test_base_manager_get_latest_base_manager_hash(base_manager):
     with pytest.raises(NotImplementedError):
         base_manager._get_latest_hash('archive_name')
 
 
-def test_get_authority_name(base_manager):
+def test_base_manager_get_authority_name(base_manager):
     with pytest.raises(NotImplementedError):
         base_manager._get_authority_name('archive_name')
 
 
-def test_get_archive_path(base_manager):
+def test_base_manager_get_archive_path(base_manager):
     with pytest.raises(NotImplementedError):
         base_manager._get_archive_path('archive_name')
 
 
-def test_delete_archive_record(base_manager):
+def test_base_manager_delete_archive_record(base_manager):
     with pytest.raises(NotImplementedError):
         base_manager._delete_archive_record('archive_name')
 
 
-def test_get_table_names(base_manager):
+def test_base_manager_get_table_names(base_manager):
     with pytest.raises(NotImplementedError):
         base_manager._get_table_names()
 
 
-def test_create_archive_table(base_manager):
+def test_base_manager_create_archive_table(base_manager):
     with pytest.raises(NotImplementedError):
         base_manager._create_archive_table('table_name')
 
 
-def test_create_spec_config(base_manager):
+def test_base_manager_create_spec_config(base_manager):
     with pytest.raises(NotImplementedError):
-        base_manager._create_spec_config('table_name')
+        base_manager._create_spec_config('table_name', [{}, {}, {}])
 
 
-def test_update_spec_config(base_manager):
+def test_base_manager_update_spec_config(base_manager):
     with pytest.raises(NotImplementedError):
         base_manager._update_spec_config('required_user_config', {})
 
@@ -191,11 +191,21 @@ def test_update_spec_config(base_manager):
         base_manager._update_spec_config('required_archive_metadata', {})
 
 
-def test_delete_table(base_manager):
+def test_base_manager_delete_table(base_manager):
     with pytest.raises(NotImplementedError):
         base_manager._delete_table('table_name')
 
 
-def test_get_version_history(base_manager):
+def test_base_manager_get_version_history(base_manager):
     with pytest.raises(NotImplementedError):
         base_manager._get_version_history('archive_name')
+
+
+def test_base_manager_search(base_manager):
+    with pytest.raises(NotImplementedError):
+        base_manager._search('archive_name', ['term1', 'term2'])
+
+
+def test_base_manager_set_tags(base_manager):
+    with pytest.raises(NotImplementedError):
+        base_manager._set_tags('archive_name', ['term1', 'term2'])

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -14,13 +14,13 @@ def base_manager():
 
 def test_spec_table_creation(manager_with_spec):
 
-    assert 'standalone-test-table.spec' in manager_with_spec.table_names
+    assert 'spec-test.spec' in manager_with_spec.table_names
 
 
 def test_spec_config_creation(manager_with_spec):
 
     assert len(manager_with_spec._get_spec_documents(
-        'standalone-test-table')) == 3
+        'spec-test')) == 3
 
 
 def test_spec_config_update_metadata(manager_with_spec):
@@ -46,7 +46,7 @@ def test_manager_spec_setup(api_with_spec, auth1):
 
     api_with_spec.user_config.update(user_config)
     assert api_with_spec.manager.config[
-        'table_name'] == 'standalone-test-table'
+        'table_name'] == 'spec-test'
 
     api_with_spec.create('my_spec_test_archive', metadata=metadata_config)
 

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -72,7 +72,7 @@ def test_manager_spec_setup(api_with_spec, auth1):
     assert api_with_spec.manager._get_authority_name(
         'my_spec_test_archive') == 'auth'
     assert api_with_spec.manager._get_archive_path(
-        'my_spec_test_archive') == 'my/spec/test/archive'
+        'my_spec_test_archive') == 'my_spec_test_archive'
 
     with pytest.raises(AssertionError):
         api_with_spec.create(


### PR DESCRIPTION
In this pr
----------

* archive pattern constraints
* stop coercing underscores to slashes in archive_path
* drop `archive_path` argument from `DataAPI.create`

Addresses #168 

Archive pattern constraints
------------------------------

List of regex patterns that must match archive_name before archive creation is allowed

Create an archive pattern using `manager.set_required_archive_patterns`. e.g. require only `\w`, `.`, or `/` characters:

```python
>>> api = get_api()
>>> api.manager.set_required_archive_patterns([r'^[\w\/\.]+$'])
```
Now, archives that do not match this will not be supported:
```python
>>> api.create('!!!.txt')
Traceback (most recent call last):
...
ValueError: archive name does not match pattern '^[\w\/\.]+$'
```
