### PR TITLE
0.6.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
     - DATAFS_TEST_ENV=xarray
 
 matrix:
-  allow_failures:
+  exclude:
     - python: pypy
       env: DATAFS_TEST_ENV=xarray
 

--- a/datafs/datafs.py
+++ b/datafs/datafs.py
@@ -187,12 +187,21 @@ def configure(ctx, helper, edit):
 @click.argument('archive_name')
 @click.option('--authority_name', default=None)
 @click.option('--versioned/--not-versioned', default=True)
+@click.option('-t', '--tag', multiple=True)
 @click.option('--helper', is_flag=True)
 @click.pass_context
-def create(ctx, archive_name, authority_name, versioned=True, helper=False):
+def create(
+        ctx,
+        archive_name,
+        authority_name,
+        versioned=True,
+        tag=None,
+        helper=False):
     '''
     Create an archive
     '''
+
+    tags = list(tag)
 
     _generate_api(ctx)
     args, kwargs = _parse_args_and_kwargs(ctx.args)
@@ -203,6 +212,7 @@ def create(ctx, archive_name, authority_name, versioned=True, helper=False):
         authority_name=authority_name,
         versioned=versioned,
         metadata=kwargs,
+        tags=tags,
         helper=helper)
 
     verstring = 'versioned archive' if versioned else 'archive'
@@ -358,6 +368,54 @@ def get_dependencies(ctx, archive_name, version):
     click.echo('\n'.join(deps))
 
 
+@cli.command(short_help='Add tags to an archive')
+@click.argument('archive_name')
+@click.argument('tags', nargs=-1)
+@click.pass_context
+def add_tags(ctx, archive_name, tags):
+    '''
+    Add tags to an archive
+    '''
+
+    _generate_api(ctx)
+
+    var = ctx.obj.api.get_archive(archive_name)
+
+    var.add_tags(*tags)
+
+
+@cli.command(short_help='Remove tags from an archive')
+@click.argument('archive_name')
+@click.argument('tags', nargs=-1)
+@click.pass_context
+def delete_tags(ctx, archive_name, tags):
+    '''
+    Remove tags from an archive
+    '''
+
+    _generate_api(ctx)
+
+    var = ctx.obj.api.get_archive(archive_name)
+
+    var.delete_tags(*tags)
+
+
+@cli.command(short_help='Print tags assigned to an archive')
+@click.argument('archive_name')
+@click.pass_context
+def get_tags(ctx, archive_name):
+    '''
+    Print tags assigned to an archive
+    '''
+
+    _generate_api(ctx)
+
+    var = ctx.obj.api.get_archive(archive_name)
+
+    click.echo(' '.join(var.get_tags()), nl=False)
+    print('')
+
+
 @cli.command(short_help='Download an archive')
 @click.argument('archive_name')
 @click.argument('filepath')
@@ -473,22 +531,20 @@ cli.add_command(filter_archives, name='filter')
 
 
 @cli.command(short_help='List all archives matching tag search criteria')
-@click.argument('query_tags', nargs=-1)
+@click.argument('tags', nargs=-1)
 @click.option(
     '--prefix',
     default=None,
     help='filter archives based on initial character pattern')
 @click.pass_context
-def search(ctx, query_tags, prefix=None):
+def search(ctx, tags, prefix=None):
     '''
     List all archives matching tag search criteria
     '''
 
     _generate_api(ctx)
 
-    assert isinstance(query_tags, tuple)
-
-    for i, match in enumerate(ctx.obj.api.search(*query_tags, prefix=prefix)):
+    for i, match in enumerate(ctx.obj.api.search(*tags, prefix=prefix)):
 
         click.echo(match, nl=False)
         print('')

--- a/datafs/managers/manager_mongo.py
+++ b/datafs/managers/manager_mongo.py
@@ -4,30 +4,7 @@ from __future__ import absolute_import
 from datafs.managers.manager import BaseDataManager
 
 from pymongo import MongoClient
-from pymongo.errors import ServerSelectionTimeoutError, DuplicateKeyError
-
-
-class ConnectionError(IOError):
-    pass
-
-
-def catch_timeout(func):
-    '''
-    Decorator for wrapping MongoDB connections
-    '''
-
-    def inner(*args, **kwargs):
-        msg = 'Connection to MongoDB server could not be established. '\
-            'Make sure you are running a MongoDB server and that the MongoDB '\
-            'Manager has been configured to connect over the correct port. '\
-            'For more information see '\
-            'https://docs.mongodb.com/manual/tutorial/.'
-        try:
-            return func(*args, **kwargs)
-        except ServerSelectionTimeoutError:
-            raise ConnectionError(msg)
-
-    return inner
+from pymongo.errors import DuplicateKeyError
 
 
 class MongoDBManager(BaseDataManager):
@@ -81,7 +58,6 @@ class MongoDBManager(BaseDataManager):
     def table_name(self):
         return self._table_name
 
-    @catch_timeout
     def _get_table_names(self):
         return self.db.collection_names(include_system_collections=False)
 
@@ -125,7 +101,6 @@ class MongoDBManager(BaseDataManager):
 
     # Private methods (to be implemented!)
 
-    @catch_timeout
     def _update(self, archive_name, version_metadata):
         self.collection.update(
             {"_id": archive_name},
@@ -133,14 +108,9 @@ class MongoDBManager(BaseDataManager):
 
     def _update_metadata(self, archive_name, archive_metadata):
 
-        required_metadata_keys = self._get_required_archive_metadata().keys()
         for key, val in archive_metadata.items():
-            if key in required_metadata_keys and val is None:
-                raise ValueError(
-                    'Value for key {} is None. '.format(key) +
-                    'None cannot be a value for required metadata')
 
-            elif val is None:
+            if val is None:
                 self.collection.update(
                     {"_id": archive_name},
                     {"$unset": {"archive_metadata.{}".format(key): ""}})
@@ -156,7 +126,6 @@ class MongoDBManager(BaseDataManager):
             {"_id": document_name},
             {"$set": {'config': spec}}, upsert=True)
 
-    @catch_timeout
     def _create_archive(
             self,
             archive_name,
@@ -167,19 +136,13 @@ class MongoDBManager(BaseDataManager):
         except DuplicateKeyError:
             raise KeyError('Archive "{}" already exists'.format(archive_name))
 
-    @catch_timeout
-    def _create_spec_config(self, table_name):
+    def _create_spec_config(self, table_name, spec_documents):
 
         if self._spec_coll is None:
             self._spec_coll = self.db[table_name + '.spec']
 
-        itrbl = [
-            {'_id': x, 'config': {}}
-            for x in ('required_user_config', 'required_archive_metadata')]
+        self.spec_collection.insert_many(spec_documents)
 
-        self.spec_collection.insert_many(itrbl)
-
-    @catch_timeout
     def _get_archive_listing(self, archive_name):
         '''
         Return full document for ``{_id:'archive_name'}``
@@ -224,13 +187,3 @@ class MongoDBManager(BaseDataManager):
 
     def _get_spec_documents(self, table_name):
         return [item for item in self.spec_collection.find({})]
-
-    def _get_required_user_config(self):
-
-        return self.spec_collection.find_one(
-            {'_id': 'required_user_config'})['config']
-
-    def _get_required_archive_metadata(self):
-
-        return self.spec_collection.find_one(
-            {'_id': 'required_archive_metadata'})['config']

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -6,8 +6,9 @@ Using the Command-Line Interface
 
 .. toctree::
 
-   	cli.creating_archives
-   	cli.io
-   	cli.metadata
-   	cli.versioning
-   	cli.dependencies
+    cli.creating_archives
+    cli.tagging
+    cli.io
+    cli.metadata
+    cli.versioning
+    cli.dependencies

--- a/docs/cli.tagging.rst
+++ b/docs/cli.tagging.rst
@@ -1,0 +1,63 @@
+.. _cli-tagging:
+
+================
+Tagging Archives
+================
+
+You can tag archives from the command line interface or from :ref:`python <pythonapi-tagging>`.
+
+View the source for the code samples on this page in :ref:`snippets-cli-tagging`.
+
+Tagging on archive creation
+---------------------------
+
+When creating archives, you can specify tags using the ``--tag`` argument. You can specify as many as you would like:
+
+.. include:: ../examples/snippets/cli_tagging.py
+    :start-after: .. EXAMPLE-BLOCK-1-START
+    :end-before: .. EXAMPLE-BLOCK-1-END
+
+You can then search for archives that have these tags using the ``search`` command:
+
+.. include:: ../examples/snippets/cli_tagging.py
+    :start-after: .. EXAMPLE-BLOCK-2-START
+    :end-before: .. EXAMPLE-BLOCK-2-END
+
+Searching for multiple tags yields the set of archives that match all of the criteria:
+
+.. include:: ../examples/snippets/cli_tagging.py
+    :start-after: .. EXAMPLE-BLOCK-3-START
+    :end-before: .. EXAMPLE-BLOCK-3-END
+
+Searches that include a set of tags not jointly found in any archives yield no results:
+
+.. include:: ../examples/snippets/cli_tagging.py
+    :start-after: .. EXAMPLE-BLOCK-4-START
+    :end-before: .. EXAMPLE-BLOCK-4-END
+
+Viewing and modifying tags on existing archives
+-----------------------------------------------
+
+Tags can be listed using the ``get_tags`` command:
+
+.. include:: ../examples/snippets/cli_tagging.py
+    :start-after: .. EXAMPLE-BLOCK-5-START
+    :end-before: .. EXAMPLE-BLOCK-5-END
+
+You can add tags to an archive using the ``add_tags`` command:
+
+.. include:: ../examples/snippets/cli_tagging.py
+    :start-after: .. EXAMPLE-BLOCK-6-START
+    :end-before: .. EXAMPLE-BLOCK-6-END
+
+
+Removing tags from an archive
+-----------------------------
+
+Specific tags can be removed from an archive using the ``delete_tags`` command:
+
+.. include:: ../examples/snippets/cli_tagging.py
+    :start-after: .. EXAMPLE-BLOCK-7-START
+    :end-before: .. EXAMPLE-BLOCK-7-END
+
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,3 +39,6 @@ History
 =======
 
 DataFS was developed for use by the `Climate Impact Lab <http://impactlab.org>`_. Check us out on `github <https://github.com/ClimateImpactLab>`_.
+
+.. meta::
+   :description: DataFS Data Management System Documentation

--- a/docs/pythonapi.rst
+++ b/docs/pythonapi.rst
@@ -7,8 +7,9 @@ Using the Python API
 
 .. toctree::
 
-   	pythonapi.creating_archives
-   	pythonapi.io
-   	pythonapi.metadata
-   	pythonapi.versioning
-   	pythonapi.dependencies
+    pythonapi.creating_archives
+    pythonapi.tagging
+    pythonapi.io
+    pythonapi.metadata
+    pythonapi.versioning
+    pythonapi.dependencies

--- a/docs/pythonapi.tagging.rst
+++ b/docs/pythonapi.tagging.rst
@@ -1,0 +1,63 @@
+.. _pythonapi-tagging:
+
+================
+Tagging Archives
+================
+
+You can tag archives from within python or using the :ref:`command line interface <cli-tagging>`.
+
+View the source for the code samples on this page in :ref:`snippets-pythonapi-tagging`.
+
+Tagging on archive creation
+---------------------------
+
+When creating archives, you can specify tags using the ``tags`` argument. You can specify as many as you would like as elements in a list:
+
+.. include:: ../examples/snippets/pythonapi_tagging.py
+    :start-after: .. EXAMPLE-BLOCK-1-START
+    :end-before: .. EXAMPLE-BLOCK-1-END
+
+You can then search for archives that have these tags using the :py:meth:`~datafs.DataAPI.search` method:
+
+.. include:: ../examples/snippets/pythonapi_tagging.py
+    :start-after: .. EXAMPLE-BLOCK-2-START
+    :end-before: .. EXAMPLE-BLOCK-2-END
+
+Searching for multiple tags yields the set of archives that match all of the criteria:
+
+.. include:: ../examples/snippets/pythonapi_tagging.py
+    :start-after: .. EXAMPLE-BLOCK-3-START
+    :end-before: .. EXAMPLE-BLOCK-3-END
+
+Searches that include a set of tags not jointly found in any archives yield no results:
+
+.. include:: ../examples/snippets/pythonapi_tagging.py
+    :start-after: .. EXAMPLE-BLOCK-4-START
+    :end-before: .. EXAMPLE-BLOCK-4-END
+
+Viewing and modifying tags on existing archives
+-----------------------------------------------
+
+Tags can be listed using the :py:meth:`~datafs.core.data_archive.DataArchive.get_tags` method:
+
+.. include:: ../examples/snippets/pythonapi_tagging.py
+    :start-after: .. EXAMPLE-BLOCK-5-START
+    :end-before: .. EXAMPLE-BLOCK-5-END
+
+You can add tags to an archive using the :py:meth:`~datafs.core.data_archive.DataArchive.add_tags` method:
+
+.. include:: ../examples/snippets/pythonapi_tagging.py
+    :start-after: .. EXAMPLE-BLOCK-6-START
+    :end-before: .. EXAMPLE-BLOCK-6-END
+
+
+Removing tags from an archive
+-----------------------------
+
+Specific tags can be removed from an archive using the :py:meth:`~datafs.core.data_archive.DataArchive.delete_tags` method:
+
+.. include:: ../examples/snippets/pythonapi_tagging.py
+    :start-after: .. EXAMPLE-BLOCK-7-START
+    :end-before: .. EXAMPLE-BLOCK-7-END
+
+

--- a/docs/samples.cli.tagging.rst
+++ b/docs/samples.cli.tagging.rst
@@ -1,0 +1,4 @@
+
+.. include:: ../examples/snippets/cli_tagging.py
+    :start-after: '''
+    :end-before: '''

--- a/docs/samples.pythonapi.tagging.rst
+++ b/docs/samples.pythonapi.tagging.rst
@@ -1,0 +1,4 @@
+
+.. include:: ../examples/snippets/pythonapi_tagging.py
+    :start-after: '''
+    :end-before: '''

--- a/docs/samples.rst
+++ b/docs/samples.rst
@@ -6,7 +6,9 @@ Documentation Code Source
 .. toctree::
     :maxdepth: 1
 
+    samples.cli.tagging
     samples.pythonapi.creating.archives
+    samples.pythonapi.tagging
     samples.pythonapi.io
     samples.pythonapi.metadata
     samples.pythonapi.versioning

--- a/examples/caching.py
+++ b/examples/caching.py
@@ -37,7 +37,7 @@ For this example we'll use an AWS S3 store. Any filesystem will work, though:
 Create an archive
 
     >>> var = api.create(
-    ...     'caching_archive',
+    ...     'caching/archive.txt',
     ...     metadata = dict(description = 'My cached remote archive'),
     ...     authority_name='aws')
     >>>

--- a/examples/snippets/cli_tagging.py
+++ b/examples/snippets/cli_tagging.py
@@ -1,0 +1,146 @@
+r'''
+.. _snippets-cli-tagging:
+
+Command Line Interface: Tagging
+===============================
+
+This is the tested source code for the snippets used in :ref:`cli-tagging`. The
+config file we're using in this example can be downloaded
+:download:`here <../examples/snippets/resources/datafs.yml>`.
+
+Example 1
+---------
+
+Displayed example 1 code:
+
+.. EXAMPLE-BLOCK-1-START
+
+.. code-block:: bash
+
+    $ datafs create archive1 --tag "foo" --tag "bar" --description \
+    >     "tag test 1 has bar"
+    created versioned archive <DataArchive local://archive1>
+
+    $ datafs create archive2 --tag "foo" --tag "baz" --description \
+    >     "tag test 2 has baz"
+    created versioned archive <DataArchive local://archive2>
+
+.. EXAMPLE-BLOCK-1-END
+
+
+Example 2
+---------
+
+.. EXAMPLE-BLOCK-2-START
+
+.. code-block:: bash
+
+    $ datafs search bar
+    archive1
+
+    $ datafs search baz
+    archive2
+
+    $ datafs search foo
+    archive1
+    archive2
+
+.. EXAMPLE-BLOCK-2-END
+
+
+Example 3
+---------
+
+.. EXAMPLE-BLOCK-3-START
+
+.. code-block:: bash
+
+    $ datafs create archive3 --tag "foo" --tag "bar" --tag "baz" \
+    >     --description 'tag test 3 has all the tags!'
+    created versioned archive <DataArchive local://archive3>
+
+    $ datafs search bar foo
+    archive1
+    archive3
+
+    $ datafs search bar foo baz
+    archive3
+
+.. EXAMPLE-BLOCK-3-END
+
+Example 4
+---------
+
+.. EXAMPLE-BLOCK-4-START
+
+.. code-block:: bash
+
+    $ datafs search qux
+
+    $ datafs search foo qux
+
+
+.. EXAMPLE-BLOCK-4-END
+
+
+Example 5
+---------
+
+.. EXAMPLE-BLOCK-5-START
+
+.. code-block:: bash
+
+    $ datafs get_tags archive1
+    foo bar
+
+
+.. EXAMPLE-BLOCK-5-END
+
+
+Example 6
+---------
+
+.. EXAMPLE-BLOCK-6-START
+
+.. code-block:: bash
+
+    $ datafs add_tags archive1 qux
+
+    $ datafs search foo qux
+    archive1
+
+
+.. EXAMPLE-BLOCK-6-END
+
+
+Example 7
+---------
+
+.. EXAMPLE-BLOCK-7-START
+
+.. code-block:: bash
+
+    $ datafs delete_tags archive1 foo bar
+
+    $ datafs search foo bar
+    archive3
+
+
+.. EXAMPLE-BLOCK-7-END
+
+
+Teardown
+--------
+
+.. code-block:: bash
+
+    $ datafs delete archive1
+    deleted archive <DataArchive local://archive1>
+
+    $ datafs delete archive2
+    deleted archive <DataArchive local://archive2>
+
+    $ datafs delete archive3
+    deleted archive <DataArchive local://archive3>
+
+'''

--- a/examples/snippets/pythonapi_tagging.py
+++ b/examples/snippets/pythonapi_tagging.py
@@ -1,0 +1,232 @@
+'''
+.. _snippets-pythonapi-tagging:
+
+Python API: Tagging
+===================
+
+This is the tested source code for the snippets used in
+:ref:`pythonapi-tagging`. The config file we're using in this example
+can be downloaded :download:`here <../examples/snippets/resources/datafs.yml>`.
+
+Setup
+-----
+
+.. code-block:: python
+
+    >>> import datafs
+    >>> from fs.tempfs import TempFS
+
+We test with the following setup:
+
+.. code-block:: python
+
+    >>> api = datafs.get_api(
+    ...     config_file='examples/snippets/resources/datafs.yml')
+    ...
+
+This assumes that you have a config file at the above location. The config file
+we're using in this example can be downloaded
+:download:`here <../examples/snippets/resources/datafs.yml>`.
+
+clean up any previous test failures
+
+.. code-block:: python
+
+    >>> try:
+    ...     api.delete_archive('archive1')
+    ... except (KeyError, OSError):
+    ...     pass
+    ...
+    >>> try:
+    ...     api.delete_archive('archive2')
+    ... except (KeyError, OSError):
+    ...     pass
+    ...
+    >>> try:
+    ...     api.delete_archive('archive3')
+    ... except (KeyError, OSError):
+    ...     pass
+    ...
+    >>> try:
+    ...     api.manager.delete_table('DataFiles')
+    ... except KeyError:
+    ...     pass
+    ...
+
+Add a fresh manager table:
+
+.. code-block:: python
+
+    >>> api.manager.create_archive_table('DataFiles')
+
+Example 1
+---------
+
+Displayed example 1 code:
+
+.. EXAMPLE-BLOCK-1-START
+
+.. code-block:: python
+
+    >>> archive1 = api.create(
+    ...      'archive1',
+    ...      tags=["foo", "bar"],
+    ...      metadata={'description': 'tag test 1 has bar'})
+    ...
+    >>> archive2 = api.create(
+    ...      'archive2',
+    ...      tags=["foo", "baz"],
+    ...      metadata={'description': 'tag test 1 has baz'})
+    ...
+
+.. EXAMPLE-BLOCK-1-END
+
+
+Example 2
+---------
+
+.. EXAMPLE-BLOCK-2-START
+
+.. code-block:: python
+
+    >>> list(api.search('bar')) # doctest: +SKIP
+    ['archive1']
+
+    >>> list(api.search('baz')) # doctest: +SKIP
+    ['archive2']
+
+    >>> list(api.search('foo')) # doctest: +SKIP
+    ['archive1', 'archive2']
+
+.. EXAMPLE-BLOCK-2-END
+
+Actual Example Block 2 Test
+
+.. code-block:: python
+
+    >>> assert set(api.search('bar')) == {'archive1'}
+    >>> assert set(api.search('baz')) == {'archive2'}
+    >>> assert set(api.search('foo')) == {'archive1', 'archive2'}
+
+
+Example 3
+---------
+
+.. EXAMPLE-BLOCK-3-START
+
+.. code-block:: python
+
+    >>> archive3 = api.create(
+    ...      'archive3',
+    ...      tags=["foo", "bar", "baz"],
+    ...      metadata={'description': 'tag test 3 has all the tags!'})
+    ...
+
+    >>> list(api.search('bar', 'foo')) # doctest: +SKIP
+    ['archive1', 'archive3']
+
+    >>> list(api.search('bar', 'foo', 'baz')) # doctest: +SKIP
+    ['archive3']
+
+.. EXAMPLE-BLOCK-3-END
+
+Actual example block 3 search test:
+
+.. code-block:: python
+
+    >>> assert set(api.search('bar', 'foo')) == {'archive1', 'archive3'}
+    >>> assert set(api.search('bar', 'foo', 'baz')) == {'archive3'}
+
+Example 4
+---------
+
+.. EXAMPLE-BLOCK-4-START
+
+.. code-block:: python
+
+    >>> list(api.search('qux')) # doctest: +SKIP
+    []
+    >>> list(api.search('foo', 'qux')) # doctest: +SKIP
+    []
+
+.. EXAMPLE-BLOCK-4-END
+
+Actual example block 4 test
+
+.. code-block:: python
+
+    >>> assert set(api.search('qux')) == set([])
+
+Example 5
+---------
+
+.. EXAMPLE-BLOCK-5-START
+
+.. code-block:: python
+
+    >>> archive1.get_tags() # doctest: +SKIP
+    ['foo', 'bar']
+
+
+.. EXAMPLE-BLOCK-5-END
+
+Actual example block 5 test
+
+.. code-block:: python
+
+    >>> assert set(archive1.get_tags()) == {'foo', 'bar'}
+
+
+Example 6
+---------
+
+.. EXAMPLE-BLOCK-6-START
+
+.. code-block:: python
+
+    >>> archive1.add_tags('qux')
+    >>>
+    >>> list(api.search('foo', 'qux')) # doctest: +SKIP
+    ['archive1']
+
+
+.. EXAMPLE-BLOCK-6-END
+
+
+Actual example block 6 search test
+
+.. code-block:: python
+
+    >>> assert set(api.search('foo', 'qux')) == {'archive1'}
+
+Example 7
+---------
+
+.. EXAMPLE-BLOCK-7-START
+
+.. code-block:: python
+
+    >>> archive1.delete_tags('foo', 'bar')
+    >>>
+    >>> list(api.search('foo', 'bar')) # doctest: +SKIP
+    ['archive3']
+
+
+.. EXAMPLE-BLOCK-7-END
+
+Actual example block 7 search test
+
+.. code-block:: python
+
+    >>> assert set(api.search('foo', 'bar')) == {'archive3'}
+
+Teardown
+--------
+
+.. code-block:: python
+
+    >>> archive1.delete()
+    >>> archive2.delete()
+    >>> archive3.delete()
+
+'''

--- a/tests/cli_snippets/test_cli_tagging.py
+++ b/tests/cli_snippets/test_cli_tagging.py
@@ -1,0 +1,14 @@
+
+from __future__ import absolute_import
+
+import pytest
+from examples.snippets import cli_tagging
+
+
+@pytest.mark.examples
+@pytest.mark.cli_snippets
+def test_cli_metadata_snippets(cli_validator):
+
+    # Snippet 1
+
+    cli_validator(cli_tagging.__doc__)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -233,7 +233,7 @@ def cache2():
 @pytest.yield_fixture
 def manager_with_spec(mgr_name):
 
-    with prep_manager(mgr_name, table_name='standalone-test-table') as manager:
+    with prep_manager(mgr_name, table_name='spec-test') as manager:
 
         metadata_config = {
             'description': 'some metadata'
@@ -252,6 +252,17 @@ def manager_with_spec(mgr_name):
 
 
 @pytest.yield_fixture
+def manager_with_pattern(mgr_name):
+
+    with prep_manager(mgr_name, table_name='pattern-test') as manager:
+
+        GCP_PATTERNS = [r'^(TLD1/(sub1|sub2|sub3)|TLD2/(sub1|sub2|sub3))']
+        manager.set_required_archive_patterns(GCP_PATTERNS)
+
+        yield manager
+
+
+@pytest.yield_fixture
 def api_with_spec(manager_with_spec, auth1):
 
     api = DataAPI(
@@ -259,6 +270,17 @@ def api_with_spec(manager_with_spec, auth1):
         contact='my.email@example.com')
 
     api.attach_manager(manager_with_spec)
+    api.attach_authority('auth', auth1)
+
+    yield api
+
+
+@pytest.yield_fixture
+def api_with_pattern(manager_with_pattern, auth1):
+
+    api = DataAPI()
+
+    api.attach_manager(manager_with_pattern)
     api.attach_authority('auth', auth1)
 
     yield api
@@ -382,7 +404,7 @@ def api_with_diverse_archives(request):
     PARS = 5
     CONF = 3
 
-    with prep_manager(request.param) as manager:
+    with prep_manager(request.param, table_name='diverse') as manager:
 
         api = DataAPI(
             username='My Name',

--- a/tests/test_archive_name_pattern.py
+++ b/tests/test_archive_name_pattern.py
@@ -1,0 +1,36 @@
+import pytest
+
+
+@pytest.mark.pattern
+def test_required_archive_patterns(api_with_pattern):
+
+    assert api_with_pattern.manager.required_archive_patterns == [
+            r'^(TLD1/(sub1|sub2|sub3)|TLD2/(sub1|sub2|sub3))']
+
+    archive = api_with_pattern.create(
+        'TLD1/sub1/substring1/substring1a.csv',
+        metadata=dict(description='some description'))
+
+    assert archive.archive_name == 'TLD1/sub1/substring1/substring1a.csv'
+
+    archive2 = api_with_pattern.create(
+        'TLD2/sub2/substring1/substring1a.csv',
+        metadata=dict(description='some description'))
+
+    assert archive2.archive_name == 'TLD2/sub2/substring1/substring1a.csv'
+
+    archive3 = api_with_pattern.create(
+        'TLD2/sub3/substring1/substring1a.csv',
+        metadata=dict(description='some description'))
+
+    assert archive3.archive_name == 'TLD2/sub3/substring1/substring1a.csv'
+
+    with pytest.raises(ValueError):
+        api_with_pattern.create(
+            'SOME/string1/string2/string3.csv',
+            metadata=dict(description='some description'))
+
+    with pytest.raises(ValueError):
+        api_with_pattern.create(
+            'TLD1_sub1_substring1.txt',
+            metadata=dict(description='some description'))

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -9,6 +9,7 @@ from examples.preconfigured import preconfigured
 from examples.subclassing import client
 from examples.snippets import (
     pythonapi_creating_archives,
+    pythonapi_tagging,
     pythonapi_dependencies,
     pythonapi_io,
     pythonapi_metadata,
@@ -96,6 +97,13 @@ def test_preconfigured():
 @pytest.mark.python_snippets
 def test_docs_pythonapi_creating_archives(example_snippet_working_dirs):
     failures, _ = doctest.testmod(pythonapi_creating_archives, report=True)
+    assert failures == 0
+
+
+@pytest.mark.examples
+@pytest.mark.python_snippets
+def test_docs_pythonapi_tagging(example_snippet_working_dirs):
+    failures, _ = doctest.testmod(pythonapi_tagging, report=True)
     assert failures == 0
 
 

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -14,13 +14,13 @@ def base_manager():
 
 def test_spec_table_creation(manager_with_spec):
 
-    assert 'standalone-test-table.spec' in manager_with_spec.table_names
+    assert 'spec-test.spec' in manager_with_spec.table_names
 
 
 def test_spec_config_creation(manager_with_spec):
 
     assert len(manager_with_spec._get_spec_documents(
-        'standalone-test-table')) == 2
+        'spec-test')) == 3
 
 
 def test_spec_config_update_metadata(manager_with_spec):
@@ -46,7 +46,7 @@ def test_manager_spec_setup(api_with_spec, auth1):
 
     api_with_spec.user_config.update(user_config)
     assert api_with_spec.manager.config[
-        'table_name'] == 'standalone-test-table'
+        'table_name'] == 'spec-test'
 
     api_with_spec.create('my_spec_test_archive', metadata=metadata_config)
 
@@ -72,7 +72,7 @@ def test_manager_spec_setup(api_with_spec, auth1):
     assert api_with_spec.manager._get_authority_name(
         'my_spec_test_archive') == 'auth'
     assert api_with_spec.manager._get_archive_path(
-        'my_spec_test_archive') == 'my/spec/test/archive'
+        'my_spec_test_archive') == 'my_spec_test_archive'
 
     with pytest.raises(AssertionError):
         api_with_spec.create(
@@ -118,72 +118,72 @@ def test_manager_spec_setup_api_metadata(api_with_spec, auth1):
         api_with_spec.create('my_api_test_archive', metadata={})
 
 
-def test_update(base_manager):
+def test_base_manager_update(base_manager):
     with pytest.raises(NotImplementedError):
         base_manager._update('archive_name', {})
 
 
-def test_create_archive(base_manager):
+def test_base_manager_create_archive(base_manager):
     with pytest.raises(NotImplementedError):
         base_manager._create_archive('archive_name', {})
 
 
-def test_create_if_not_exists(base_manager):
+def test_base_manager_create_if_not_exists(base_manager):
     with pytest.raises(NotImplementedError):
         base_manager._create_if_not_exists('archive_name', {})
 
 
-def test_get_archives(base_manager):
+def test_base_manager_get_archives(base_manager):
     with pytest.raises(NotImplementedError):
         base_manager._get_archives()
 
 
-def test_get_archive_listing(base_manager):
+def test_base_manager_get_archive_listing(base_manager):
     with pytest.raises(NotImplementedError):
         base_manager._get_archive_listing('archive_name')
 
 
-def test_get_archive_metadata(base_manager):
+def test_base_manager_get_archive_metadata(base_manager):
     with pytest.raises(NotImplementedError):
         base_manager._get_archive_metadata('archive_name')
 
 
-def test_get_latest_hash(base_manager):
+def test_base_manager_get_latest_base_manager_hash(base_manager):
     with pytest.raises(NotImplementedError):
         base_manager._get_latest_hash('archive_name')
 
 
-def test_get_authority_name(base_manager):
+def test_base_manager_get_authority_name(base_manager):
     with pytest.raises(NotImplementedError):
         base_manager._get_authority_name('archive_name')
 
 
-def test_get_archive_path(base_manager):
+def test_base_manager_get_archive_path(base_manager):
     with pytest.raises(NotImplementedError):
         base_manager._get_archive_path('archive_name')
 
 
-def test_delete_archive_record(base_manager):
+def test_base_manager_delete_archive_record(base_manager):
     with pytest.raises(NotImplementedError):
         base_manager._delete_archive_record('archive_name')
 
 
-def test_get_table_names(base_manager):
+def test_base_manager_get_table_names(base_manager):
     with pytest.raises(NotImplementedError):
         base_manager._get_table_names()
 
 
-def test_create_archive_table(base_manager):
+def test_base_manager_create_archive_table(base_manager):
     with pytest.raises(NotImplementedError):
         base_manager._create_archive_table('table_name')
 
 
-def test_create_spec_config(base_manager):
+def test_base_manager_create_spec_config(base_manager):
     with pytest.raises(NotImplementedError):
-        base_manager._create_spec_config('table_name')
+        base_manager._create_spec_config('table_name', [{}, {}, {}])
 
 
-def test_update_spec_config(base_manager):
+def test_base_manager_update_spec_config(base_manager):
     with pytest.raises(NotImplementedError):
         base_manager._update_spec_config('required_user_config', {})
 
@@ -191,21 +191,21 @@ def test_update_spec_config(base_manager):
         base_manager._update_spec_config('required_archive_metadata', {})
 
 
-def test_delete_table(base_manager):
+def test_base_manager_delete_table(base_manager):
     with pytest.raises(NotImplementedError):
         base_manager._delete_table('table_name')
 
 
-def test_get_required_user_config(base_manager):
-    with pytest.raises(NotImplementedError):
-        base_manager._get_required_user_config()
-
-
-def test_get_required_archive_metadata(base_manager):
-    with pytest.raises(NotImplementedError):
-        base_manager._get_required_archive_metadata()
-
-
-def test_get_version_history(base_manager):
+def test_base_manager_get_version_history(base_manager):
     with pytest.raises(NotImplementedError):
         base_manager._get_version_history('archive_name')
+
+
+def test_base_manager_search(base_manager):
+    with pytest.raises(NotImplementedError):
+        base_manager._search('archive_name', ['term1', 'term2'])
+
+
+def test_base_manager_set_tags(base_manager):
+    with pytest.raises(NotImplementedError):
+        base_manager._set_tags('archive_name', ['term1', 'term2'])

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -15,23 +15,23 @@ def test_config(api1_module, local_auth_module, temp_dir_mod):
 
     to_config_file(api1_module, config_file=temp_file, profile='myapi')
 
+    for i, j, k in itertools.product(*tuple([range(3) for _ in range(3)])):
+        arch = 'team{}_archive{}_var{}'.format(i+1, j+1, k+1)
+        api1_module.create(
+            arch,
+            tags=list(arch.split('_')),
+            metadata={
+                'description': 'archive_{}_{}_{} description'.format(i, j, k)})
+
     yield 'myapi', temp_file
 
 
+@pytest.mark.search
 def test_cli_search(test_config, monkeypatch):
 
     profile, config_file = test_config
 
     api = get_api(profile=profile, config_file=config_file)
-
-    for i, j, k in itertools.product(*tuple([range(3) for _ in range(3)])):
-        arch = 'team{}_archive{}_var{}'.format(i+1, j+1, k+1)
-        api.create(arch, metadata={
-                'description': 'archive_{}_{}_{} description'.format(i, j, k)})
-
-        _arch = api.get_archive(arch)
-        for _ in arch.split('_'):
-            _arch.add_tags(_)
 
     runner = CliRunner()
     prefix = ['--config-file', config_file, '--profile', 'myapi']
@@ -57,3 +57,86 @@ def test_cli_search(test_config, monkeypatch):
 
     assert result.exit_code == 0
     assert 'team2_archive2_var2' in result.output.strip().split('\n')[0]
+
+
+@pytest.mark.search
+def test_cli_tagging(test_config):
+
+    profile, config_file = test_config
+
+    runner = CliRunner()
+    prefix = ['--config-file', config_file, '--profile', profile]
+
+    # Add a tag to one archive
+    result = runner.invoke(
+        cli,
+        prefix + ['add_tags', 'team2_archive2_var2', 'newtag']
+    )
+
+    assert result.exit_code == 0
+
+    # Search using the new tag
+    result = runner.invoke(
+        cli,
+        prefix + ['search', 'newtag']
+    )
+
+    assert result.exit_code == 0
+    assert 'team2_archive2_var2' in result.output.strip().split('\n')[0]
+
+    # search using multiple tags
+    result = runner.invoke(
+        cli,
+        prefix + ['search', 'newtag', 'team2', 'archive2']
+    )
+
+    assert result.exit_code == 0
+    assert 'team2_archive2_var2' in result.output.strip().split('\n')[0]
+
+    # Search using the old tags
+    result = runner.invoke(
+        cli,
+        prefix + ['search', 'var2', 'team2', 'archive2']
+    )
+
+    assert result.exit_code == 0
+    assert 'team2_archive2_var2' in result.output.strip().split('\n')[0]
+
+    # Search using a bad tag combo
+    result = runner.invoke(
+        cli,
+        prefix + ['search', 'newtag', 'team3']
+    )
+
+    assert result.exit_code == 0
+    assert '' == result.output.strip()
+
+    # test get_tags
+    result = runner.invoke(
+        cli,
+        prefix + ['get_tags', 'team2_archive2_var2']
+    )
+
+    assert result.exit_code == 0
+
+    tags = {'newtag', 'team2', 'archive2', 'var2'}
+    assert set(result.output.strip().split('\n')[0].split(' ')) == tags
+
+    # test delete_tags
+    result = runner.invoke(
+        cli,
+        prefix + ['delete_tags', 'team2_archive2_var2', 'newtag']
+    )
+
+    assert result.exit_code == 0
+
+    # test get_tags
+    result = runner.invoke(
+        cli,
+        prefix + ['get_tags', 'team2_archive2_var2']
+    )
+
+    assert result.exit_code == 0
+
+    tags = {'team2', 'archive2', 'var2'}
+    assert set(result.output.strip().split('\n')[0].split(' ')) == tags


### PR DESCRIPTION
In this pr
----------

* archive pattern constraints
* set tags from command line
* stop coercing underscores to slashes in archive_path
* drop `archive_path` argument from `DataAPI.create`
* add tagging and searching documentation

Addresses #162,  #168 

Archive pattern constraints
------------------------------

List of regex patterns that must match archive_name before archive creation is allowed

Create an archive pattern using `manager.set_required_archive_patterns`. e.g. require only `\w`, `.`, or `/` characters:

```python
>>> api = get_api()
>>> api.manager.set_required_archive_patterns([r'^[\w\/\.]+$'])
```
Now, archives that do not match this will not be supported:
```python
>>> api.create('!!!.txt')
Traceback (most recent call last):
...
ValueError: archive name does not match pattern '^[\w\/\.]+$'
```

Tagging from CLI
-------------------

Added three new commands which reflect their ``DataArchive`` counterparts:
```python
datafs add_tags
datafs get_tags
datafs delete_tags
```

Additionally, a `--tag` option was added to `datafs create` so that tags could be supplied on archive creation:

```bash
datafs create my_archive --description "my description" --tag tag1 --tag tag2 --source "where it's from" --tag tag3
```