### PR TITLE
Commit messages & commit log

### DIFF
--- a/datafs/core/data_archive.py
+++ b/datafs/core/data_archive.py
@@ -605,7 +605,7 @@ class DataArchive(object):
                 time.strptime(record['updated'], '%Y%m%d-%H%M%S'))
 
             checksum = (
-                ' ({checksum})\nDate:      {timestamp}'.format(
+                ' ({algorithm} {checksum})\nDate:      {timestamp}'.format(
                     **record))
 
             if self.versioned:

--- a/datafs/core/data_archive.py
+++ b/datafs/core/data_archive.py
@@ -617,7 +617,7 @@ class DataArchive(object):
             else:
                 output = output + '\n' + (
                     click.style(
-                        'update {}'.format(i+1) + checksum,
+                        'update {}'.format(len(history) - i) + checksum,
                         fg='green'))
 
             for attr, val in sorted(record['user_config'].items()):

--- a/datafs/core/data_archive.py
+++ b/datafs/core/data_archive.py
@@ -604,19 +604,21 @@ class DataArchive(object):
                 '%a, %d %b %Y %H:%M:%S +0000',
                 time.strptime(record['updated'], '%Y%m%d-%H%M%S'))
 
+            checksum = (
+                ' ({checksum})\nDate:      {timestamp}'.format(
+                    **record))
+
             if self.versioned:
                 output = output + '\n' + (
                     click.style(
-                        'version {}'.format(record['version']), fg='green'))
+                        'version {}'.format(record['version']) + checksum,
+                        fg='green'))
 
             else:
                 output = output + '\n' + (
                     click.style(
-                        'update {}'.format(i+1), fg='green'))
-
-            output = output + (
-                ' ({checksum})\nDate:      {timestamp}'.format(
-                    **record))
+                        'update {}'.format(i+1) + checksum,
+                        fg='green'))
 
             for attr, val in sorted(record['user_config'].items()):
                 output = output + '\n' + (

--- a/datafs/core/data_archive.py
+++ b/datafs/core/data_archive.py
@@ -627,6 +627,7 @@ class DataArchive(object):
             if 'message' in record:
                 wrapper = textwrap.TextWrapper(
                     initial_indent='    ',
+                    subsequent_indent='    ',
                     width=66)
 
                 output = output + '\n\n'
@@ -634,7 +635,7 @@ class DataArchive(object):
 
             outputs.append(output)
 
-        click.echo_via_pager('\n\n'.join(reversed(outputs)))
+        click.echo_via_pager('\n\n'.join(reversed(outputs)) + '\n')
 
     def delete(self):
         '''

--- a/datafs/datafs.py
+++ b/datafs/datafs.py
@@ -218,6 +218,7 @@ def create(ctx, archive_name, authority_name, versioned=True, helper=False):
 @click.option('--bumpversion', default='patch')
 @click.option('--prerelease', default=None)
 @click.option('--dependency', multiple=True)
+@click.option('-m', '--message', default=None)
 @click.option('--string', is_flag=True)
 @click.argument('file', default=None, required=False)
 @click.pass_context
@@ -227,6 +228,7 @@ def update(
         bumpversion='patch',
         prerelease=None,
         dependency=None,
+        message=None,
         string=False,
         file=None):
     '''
@@ -246,11 +248,12 @@ def update(
     if string:
 
         with var.open(
-            'w+',
-            bumpversion=bumpversion,
-            prerelease=prerelease,
-            dependencies=dependencies_dict,
-                metadata=kwargs) as f:
+                'w+',
+                bumpversion=bumpversion,
+                prerelease=prerelease,
+                dependencies=dependencies_dict,
+                metadata=kwargs,
+                message=message) as f:
 
             if file is None:
                 for line in sys.stdin:
@@ -267,7 +270,8 @@ def update(
             bumpversion=bumpversion,
             prerelease=prerelease,
             dependencies=dependencies_dict,
-            metadata=kwargs)
+            metadata=kwargs,
+            message=message)
 
     new_version = var.get_latest_version()
 
@@ -397,6 +401,18 @@ def cat(ctx, archive_name, version):
     with var.open('r', version=version) as f:
         for chunk in iter(lambda: f.read(1024 * 1024), ''):
             click.echo(chunk)
+
+
+@cli.command(short_help='Get the version log for an archive')
+@click.argument('archive_name')
+@click.pass_context
+def log(ctx, archive_name):
+    '''
+    Get the version log for an archive
+    '''
+
+    _generate_api(ctx)
+    ctx.obj.api.get_archive(archive_name).log()
 
 
 @cli.command(short_help='Get an archive\'s metadata')

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -27,6 +27,7 @@ def test_config(api1_module, local_auth_module, temp_dir_mod):
 
 
 @pytest.mark.search
+@pytest.mark.cli
 def test_cli_search(test_config, monkeypatch):
 
     profile, config_file = test_config
@@ -60,6 +61,7 @@ def test_cli_search(test_config, monkeypatch):
 
 
 @pytest.mark.search
+@pytest.mark.cli
 def test_cli_tagging(test_config):
 
     profile, config_file = test_config


### PR DESCRIPTION
In this PR:

* "commit messages" allowed on update/open/get_local_path, stored in version_metadata
* `archive.log()` displays a paged, formatted log of changes (a la `git log`)
* `datafs log [archive_name]` displays the same output

Addresses #92 

Example
---------

```bash
$ datafs create req1

$ datafs update req1 -m "bumping to 0.1" \
>     --string "this is archive req_1 version 0.1"
uploaded data to <DataArchive auth://req1>. new version 0.1 created.

$ datafs update req1 -m "bumping to 1.0" \
>     --string "this is archive req_1 version 1.0"
uploaded data to <DataArchive auth://req1>. version bumped 0.1 --> 1.0.

$ datafs update req1 -m "bumping to 1.1" \
>     --string "this is archive req_1 version 1.1"
uploaded data to <DataArchive auth://req1>. version bumped 1.0 --> 1.1.

$ datafs log req1

version 1.1 (md5 098595725a2d35038992ec12830bbe95)
Date:      Tue, 21 Feb 2017 22:22:44 +0000
contact:   mdelgado@rhg.com
username:  Michael Delgado

    bumping to 1.1


version 1.0 (md5 74e4a735f6c1728455aa91b581f74921)
Date:      Tue, 21 Feb 2017 22:22:37 +0000
contact:   mdelgado@rhg.com
username:  Michael Delgado

    bumping to 1.0


version 0.1 (md5 dbf92db1a87605f40a4809e04cfa91ba)
Date:      Tue, 21 Feb 2017 22:22:24 +0000
contact:   mdelgado@rhg.com
username:  Michael Delgado

    bumping to 0.1
```