### PR TITLE
Fix PyUp's badge url

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,8 +15,8 @@ DataFS Data Management System
         :target: https://datafs.readthedocs.io/en/latest/?badge=latest
         :alt: Documentation Status
 
-.. image:: https://pyup.io/repos/github/climateimpactlab/datafs/shield.svg
-        :target: https://pyup.io/repos/github/climateimpactlab/datafs/
+.. image:: https://pyup.io/repos/github/ClimateImpactLab/DataFS/shield.svg
+        :target: https://pyup.io/repos/github/ClimateImpactLab/DataFS/
         :alt: Updates
 
 .. image:: https://api.codacy.com/project/badge/Grade/5e095453424840e092e71c42b8ad8b52


### PR DESCRIPTION
pyup's urls are now case sensitive. this PR fixes the pyup badge image and link urls on README.rst