### PR TITLE
Normalize names

### DIFF
--- a/datafs/config/helpers.py
+++ b/datafs/config/helpers.py
@@ -146,7 +146,7 @@ def get_api(
                     default_versions[archive] = version
 
     api = APIConstructor.generate_api_from_config(profile_config)
-    api._default_versions.update(default_versions)
+    api.default_versions = default_versions
 
     APIConstructor.attach_manager_from_config(api, profile_config)
     APIConstructor.attach_services_from_config(api, profile_config)

--- a/datafs/core/data_archive.py
+++ b/datafs/core/data_archive.py
@@ -307,7 +307,7 @@ class DataArchive(object):
         # Get default dependencies from requirements file
         default_dependencies = {
             k: v for k,
-            v in self.api._default_versions.items() if k != self.archive_name}
+            v in self.api.default_versions.items() if k != self.archive_name}
 
         # If no requirements file or is empty:
         if len(default_dependencies) == 0:

--- a/datafs/core/data_archive.py
+++ b/datafs/core/data_archive.py
@@ -57,6 +57,14 @@ class DataArchive(object):
         return "<{} {}://{}>".format(self.__class__.__name__,
                                      self.authority_name, self.archive_name)
 
+    def __eq__(self, other):
+        return (
+            isinstance(other, self.__class__) and
+            (self.archive_name == other.archive_name) and
+            (self.authority_name == other.authority_name) and
+            (self.archive_path == other.archive_path) and
+            (self.versioned == other.versioned))
+
     @property
     def versioned(self):
         return self._versioned

--- a/docs/whatsnew/v0.7.1.txt
+++ b/docs/whatsnew/v0.7.1.txt
@@ -5,12 +5,72 @@ v0.7.1 (Latest Build)
 
 New features
 ~~~~~~~~~~~~
-  - 
+
+  - Archive names are normalized in DataAPI methods. See :ref:`normalizing archive names <normalizing_archive_names>` (:issue:`220` & :issue:`235`).
+
+.. _normalizing_archive_name
+Normalizing archive names
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+:py:class:`~datafs.DataAPI` methods :py:meth:`~datafs.DataAPI.create`,
+:py:meth:`~datafs.DataAPI.get_archive`, :py:meth:`~datafs.DataAPI.batch_get_archive` and
+:py:meth:`~datafs.DataAPI.listdir`, and the :py:meth:`~datafs.DataAPI.default_versions` property,
+are normalized using ``DataAPI._normalize_archive_name()``. This allows users to create and get
+archives using leading slashes and authority names interchangably. For example, the following are
+all equivalent:
+
+.. code-block:: python
+
+    >>> api.create('my/sample/archive.txt')
+    >>> api.create('/my/sample/archive.txt')
+    >>> api.create('authority://my/sample/archive.txt')
+
+Furthermore, they can all be found using similarly flexible searches. The following will all return
+the archive_name or archive created in the above examples:
+
+.. code-block:: python
+
+    >>> api.get_archive('my/sample/archive.txt')
+    >>> api.get_archive('/my/sample/archive.txt')
+    >>> api.get_archive('authority://my/sample/archive.txt')
+    >>> api.batch_get_archive(['authority://my/sample/archive.txt'])
+    >>> api.search(prefix='my/samp')
+    >>> api.search(prefix='/my/samp')
+    >>> api.search(pattern='my/samp*')
+    >>> api.search(pattern='*my/samp*')
+    >>> api.search(pattern='/my/samp*')
+
+Search patterns do not accept authority names:
+
+    >>> api.search(prefix='authority://my') # no results
+
+
+Archive name checking
+.....................
+
+The normalization process catches illegal archive names:
+
+    >>> api.create('!!!\\\\~')
+    Traceback (most recent call last):
+    ...
+    fs.errors.InvalidCharsInPathError: Path contains invalid characters: !!!\\~
+
+This error checking is done by ``fs``, using the implementations of
+:py:meth:`~fs.base.BaseFS.validatepath` on the relevant authority. Currently, both
+:py:meth:`fs.osfs.OSFS.validatepath` and the method on whatever filesystem is used by the authority
+are both checked. This dual restriction is used because checking against OSFS restrictions is useful
+to prevent errors when using a cache.
 
 Backwards incompatible API changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-  - 
+  - Authority names are now limited to names that match ``r'[\w\-]+'``. This regex value is set by
+    the module parameter ``_VALID_AUTHORITY_PATTERNS`` in ``datafs/core/data_api.py``
+    (:issue:`186`).
+
+  - Introduces a new property :py:meth:`datafs.DataAPI.default_versions`, which does archive name
+    coersion/alignment. :py:meth:`datafs.DataAPI._default_versions` should no longer be accessed
+    under any circumstances (:issue:`220` and :issue:`235`).
 
 
 Performance Improvements

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -487,3 +487,12 @@ def api_with_diverse_archives(request):
             }
 
             yield api
+
+
+@pytest.yield_fixture(scope='function')
+def api_dual_auth(api1, auth1, auth2):
+
+    api1.attach_authority('auth1', auth1)
+    api1.attach_authority('auth2', auth2)
+
+    yield api1

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -1,0 +1,106 @@
+'''
+Tests pushing what can reasonably be expected from users to the limits
+
+Guidelines for writing tests in this module
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+'''
+
+from __future__ import absolute_import
+
+import pytest
+from datafs._compat import u
+
+
+def test_archive_creation_naming_conventions(api):
+
+    arch = api.create('my/new/archive.txt')
+
+    try:
+        # Make sure we can get the archive:
+        arch1 = api.get_archive('my/new/archive.txt')
+        assert arch1 == arch
+
+        # Make sure str/unicode isn't a problem:
+        arch2 = api.get_archive(u('my/new/archive.txt'))
+        assert arch2 == arch
+
+        # Make sure leading slash isn't a problem:
+        arch3 = api.get_archive('/my/new/archive.txt')
+        assert arch3 == arch
+
+        # Make sure authority name isn't a problem:
+        arch4 = api.get_archive('filesys://my/new/archive.txt')
+        assert arch4 == arch
+
+    finally:
+        arch.delete()
+
+
+def test_archive_creation_with_authority(api):
+
+    arch = api.create('filesys://my/new/archive.txt')
+
+    try:
+        # Make sure we can get the archive:
+        arch1 = api.get_archive('filesys://my/new/archive.txt')
+        assert arch1 == arch
+
+        # Make sure str/unicode isn't a problem:
+        arch2 = api.get_archive(u('my/new/archive.txt'))
+        assert arch2 == arch
+
+        # Make sure leading slash isn't a problem:
+        arch3 = api.get_archive('/my/new/archive.txt')
+        assert arch3 == arch
+
+        # Make sure authority name isn't a problem:
+        arch4 = api.get_archive('filesys://my/new/archive.txt')
+        assert arch4 == arch
+
+        # Make sure the wrong authority name is a problem:
+        with pytest.raises(ValueError):
+            api.get_archive('localhost://my/new/archive.txt')
+
+    finally:
+        arch.delete()
+
+
+def test_archive_creation_with_multiple_authorities(api_dual_auth):
+
+    arch = api_dual_auth.create('auth1://my/new/archive.txt')
+
+    try:
+        # Make sure we can get the archive:
+        arch1 = api_dual_auth.get_archive('my/new/archive.txt')
+        assert arch1 == arch
+
+        # Make sure str/unicode isn't a problem:
+        arch2 = api_dual_auth.get_archive(u('my/new/archive.txt'))
+        assert arch2 == arch
+
+        # Make sure leading slash isn't a problem:
+        arch3 = api_dual_auth.get_archive('/my/new/archive.txt')
+        assert arch3 == arch
+
+        # Make sure authority name matters
+        with pytest.raises(ValueError):
+            api_dual_auth.get_archive('auth2://my/new/archive.txt')
+
+        # Make sure authority name prefix isn't a problem:
+        arch4 = api_dual_auth.get_archive('auth1://my/new/archive.txt')
+        assert arch4 == arch
+
+        # Make sure bad authority names are a problem:
+        with pytest.raises(ValueError):
+            api_dual_auth.get_archive('non_authority://my/new/archive.txt')
+
+    finally:
+        arch.delete()
+
+
+def test_bad_archive_names(api):
+    with pytest.raises(ValueError):
+        arch = api.create('auth1://my\\~$archive...txt')
+        arch.delete()

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -14,6 +14,9 @@ from datafs._compat import u
 
 
 def test_archive_creation_naming_conventions(api):
+    '''
+    Addresses :issue:`220`
+    '''
 
     arch = api.create('my/new/archive.txt')
 
@@ -39,6 +42,9 @@ def test_archive_creation_naming_conventions(api):
 
 
 def test_archive_creation_with_authority(api):
+    '''
+    Addresses :issue:`220`
+    '''
 
     arch = api.create('filesys://my/new/archive.txt')
 
@@ -68,6 +74,9 @@ def test_archive_creation_with_authority(api):
 
 
 def test_archive_creation_with_multiple_authorities(api_dual_auth):
+    '''
+    Addresses :issue:`220`
+    '''
 
     arch = api_dual_auth.create('auth1://my/new/archive.txt')
 
@@ -101,6 +110,10 @@ def test_archive_creation_with_multiple_authorities(api_dual_auth):
 
 
 def test_bad_archive_names(api):
+    '''
+    Addresses :issue:`235`
+    '''
+
     with pytest.raises(ValueError):
         arch = api.create('auth1://my\\~$archive...txt')
         arch.delete()


### PR DESCRIPTION
 - [x] closes #186, #220, and #235
 - [x] tests added / passed
 - [ ] docs reflect changes
 - [x] passes ``flake8 datafs examples tests docs``
 - [x] whatsnew entry

Could probably use some docs, but this is an urgent fix we should probably push out if you're ok with it. Check out the whatsnew for an overview of the changes.

I'm pretty concerned about the possibility of archive name conflicts between `/my/archive.txt` and `my/archive.txt`. Luckily, we don't currently have any such conflicts on Dynamo, so we should be able to push this out without interruption.

This also sets restrictions on archive names using OSFS and the authority's [validatepath](http://pyfilesystem.readthedocs.io/en/latest/base.html#fs.base.FS.validatepath) method. This will cause some archives to become inaccessible. Specifically, someone (embarrassingly, I think it was me?) created some pretty shitty archives:

```bash
$ datafs filter --pattern '*"*'
"American Climate Prospectus"/climate/smme/HDD-CDD/county/001/annual/rcp45/noresm1-me/198101-210012.nc
"American Climate Prospectus"/climate/smme/HDD-CDD/county/001/annual/rcp45/access1-0/198101-210012.nc
"American Climate Prospectus"/climate/smme/HDD-CDD/county/001/annual/rcp45/cesm1-bgc/198101-210012.nc
"American Climate Prospectus"/climate/smme/HDD-CDD/county/001/annual/rcp45/gfdl-cm3/198101-210012.nc
```

We'll have to delete or rename these ourselves in order to access them once these updates are published.
