### PR TITLE
remove_dir implemented through `archive.delete()`

### DIFF
--- a/datafs/core/data_archive.py
+++ b/datafs/core/data_archive.py
@@ -657,23 +657,16 @@ class DataArchive(object):
             :ref:`Administrative Tools <admin>`
 
         '''
-
-        #authority_name, archive_name = self.api._normalize_archive_name(
-                                #self.archive_name, self.authority_name)
-        
         versions = self.get_versions()
         self.api.manager.delete_archive_record(self.archive_name)
-            
 
         for version in versions:
-            #remove the file object from the fs
             if self.authority.fs.exists(self.get_version_path(version)):
                 self.authority.fs.remove(self.get_version_path(version))
 
             if self.api.cache:
                 if self.api.cache.fs.exists(self.get_version_path(version)):
                     self.api.cache.fs.remove(self.get_version_path(version))
-
 
         if self.authority.fs.exists(self.archive_name):
             self.authority.fs.removedir(self.archive_name)
@@ -682,7 +675,6 @@ class DataArchive(object):
             if self.api.cache.fs.exists(self.archive_name):
                 self.api.cache.fs.removedir(self.archive_name)
 
-        
     def isfile(self, version=None, *args, **kwargs):
         '''
         Check whether the path exists and is a file

--- a/datafs/core/data_archive.py
+++ b/datafs/core/data_archive.py
@@ -658,10 +658,15 @@ class DataArchive(object):
 
         '''
 
+        #authority_name, archive_name = self.api._normalize_archive_name(
+                                #self.archive_name, self.authority_name)
+        
         versions = self.get_versions()
         self.api.manager.delete_archive_record(self.archive_name)
+            
 
         for version in versions:
+            #remove the file object from the fs
             if self.authority.fs.exists(self.get_version_path(version)):
                 self.authority.fs.remove(self.get_version_path(version))
 
@@ -669,6 +674,15 @@ class DataArchive(object):
                 if self.api.cache.fs.exists(self.get_version_path(version)):
                     self.api.cache.fs.remove(self.get_version_path(version))
 
+
+        if self.authority.fs.exists(self.archive_name):
+            self.authority.fs.removedir(self.archive_name)
+
+        if self.api.cache:
+            if self.api.cache.fs.exists(self.archive_name):
+                self.api.cache.fs.removedir(self.archive_name)
+
+        
     def isfile(self, version=None, *args, **kwargs):
         '''
         Check whether the path exists and is a file

--- a/docs/whatsnew/v0.7.1.txt
+++ b/docs/whatsnew/v0.7.1.txt
@@ -84,11 +84,39 @@ The normalization process catches illegal archive names:
     ...
     fs.errors.InvalidCharsInPathError: Path contains invalid characters: !!!\\~
 
+
 This error checking is done by ``fs``, using the implementations of
 :py:meth:`~fs.base.BaseFS.validatepath` on the relevant authority. Currently, both
 :py:meth:`fs.osfs.OSFS.validatepath` and the method on whatever filesystem is used by the authority
 are both checked. This dual restriction is used because checking against OSFS restrictions is useful
 to prevent errors when using a cache.
+
+
+Delete
+~~~~~~
+
+Delete archives
+
+.. code-block:: python
+
+    >>> api.listdir('tas/global')
+    [u'0.0.1', u'0.0.2']
+    >>>
+    >>> api.listdir('tas')
+    [u'regional', u'global', u'adm1', u'adm2']
+    >>>
+    >>> tasg = api.get_archive('tas/global')
+    >>> tasg.delete()
+    >>> api.get_archive('tas/global')
+    ...
+    KeyError: 'Archive "tas/global" not found'
+    >>>
+    >>> api.listdir('tas')
+    [u'regional', u'adm1', u'adm2']
+
+
+Archive-level names space is removed using the :py:meth:`fs.osfs.OSFS.removedir` method
+
 
 Backwards incompatible API changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -115,6 +143,7 @@ Bug Fixes
   - Messages are now coerced to strings, and :py:meth:`~datafs.core.data_archive.log` and the CLI ``log`` command no longer fail when used on archives with non-string messages (:issue:`232`)
   - ``examples/ondisk.py`` updated to reflect `xarray 0.9.5 <https://pypi.python.org/pypi/xarray/0.9.5) display function changes>`_ (:issue:`249`)
   - Configuration now creates the datafs app directory if it did not previously exist (:issue:`265`)
+  - Delete will now remove the archive-level namespace in the filesystem as well as the version number namespace
 
 
 Under the hood

--- a/tests/test_removedir.py
+++ b/tests/test_removedir.py
@@ -8,10 +8,9 @@ from fs.tempfs import TempFS
 from fs.errors import ResourceNotFoundError
 import pytest
 
-# test delete/noversion/delete after remove from local file system
+
 @pytest.mark.remove_dir
 def test_delete_handling(api, auth1):
-
 
     cache = TempFS()
     api.attach_authority('auth1', auth1)
@@ -25,7 +24,6 @@ def test_delete_handling(api, auth1):
 
     assert os.path.isfile(api.cache.fs.getsyspath('archive1'))
 
-    # try re-upload, with file deletion. Should be written to cache
     var.update('test_file.txt', remove=True)
     assert not os.path.isfile('test_file.txt')
 
@@ -33,17 +31,15 @@ def test_delete_handling(api, auth1):
     with pytest.raises(KeyError):
         api.get_archive('archive1')
 
-
     with pytest.raises(ResourceNotFoundError):
         f = api._authorities['auth1'].fs.open('archive1', 'r')
-    
+
     with pytest.raises(ResourceNotFoundError):
-        f = api.cache.fs.open('archive1' , 'r')
+        f = api.cache.fs.open('archive1', 'r')
 
 
 @pytest.mark.remove_dir
 def test_versioned_no_cache(api, auth1):
-
 
     api.attach_authority('auth1', auth1)
 
@@ -55,23 +51,20 @@ def test_versioned_no_cache(api, auth1):
     var2 = api.create('archive2', authority_name='auth1', versioned=True)
     var2.update('test_file1.txt')
 
-    #make sure the version is captured
     assert var2.get_version_path() == 'archive2/0.0.1'
 
     var2.delete()
-    #confirm it has been deleted from the manager
     with pytest.raises(KeyError):
         api.get_archive('archive2')
 
-    #confirm that it is not present in the fs
     with pytest.raises(ResourceNotFoundError):
-        api._authorities['auth1'].fs.open('archive2' 'r') 
+        api._authorities['auth1'].fs.open('archive2' 'r')
 
     assert api.listdir('', authority_name='auth1') == []
 
+
 @pytest.mark.remove_dir
 def test_remove_dir_multi_versions_remove(api, auth1):
-
 
     cache = TempFS()
     api.attach_authority('auth1', auth1)
@@ -85,7 +78,6 @@ def test_remove_dir_multi_versions_remove(api, auth1):
 
     with var.open('w') as f:
         f.write(u'update update')
-
 
     assert len(var.get_versions()) == 2
 
@@ -101,7 +93,6 @@ def test_remove_dir_multi_versions_remove(api, auth1):
         api.cache.fs.open('archive1', 'r')
 
     assert api.listdir('', authority_name='auth1') == []
-
 
 
 @pytest.mark.remove_dir
@@ -162,11 +153,8 @@ def test_multi_api(api1, api2, auth1, cache1, cache2, opener):
     with pytest.raises(ResourceNotFoundError):
         api1._authorities['auth1'].fs.open('myArchive', 'r')
 
-    
+    # using remove_from_cache because this archive is no longer in the manager
     archive1.remove_from_cache()
 
     with pytest.raises(ResourceNotFoundError):
         api1.cache.fs.open('myArchive', 'r')
-        
-     
-

--- a/tests/test_removedir.py
+++ b/tests/test_removedir.py
@@ -1,0 +1,172 @@
+
+from __future__ import absolute_import
+
+import os
+
+from datafs._compat import u
+from fs.tempfs import TempFS
+from fs.errors import ResourceNotFoundError
+import pytest
+
+# test delete/noversion/delete after remove from local file system
+@pytest.mark.remove_dir
+def test_delete_handling(api, auth1):
+
+
+    cache = TempFS()
+    api.attach_authority('auth1', auth1)
+    api.attach_cache(cache)
+
+    with open('test_file.txt', 'w+') as f:
+        f.write(u'this is an upload test')
+
+    var = api.create('archive1', authority_name='auth1', versioned=False)
+    var.update('test_file.txt', cache=True)
+
+    assert os.path.isfile(api.cache.fs.getsyspath('archive1'))
+
+    # try re-upload, with file deletion. Should be written to cache
+    var.update('test_file.txt', remove=True)
+    assert not os.path.isfile('test_file.txt')
+
+    var.delete()
+    with pytest.raises(KeyError):
+        api.get_archive('archive1')
+
+
+    with pytest.raises(ResourceNotFoundError):
+        f = api._authorities['auth1'].fs.open('archive1', 'r')
+    
+    with pytest.raises(ResourceNotFoundError):
+        f = api.cache.fs.open('archive1' , 'r')
+
+
+@pytest.mark.remove_dir
+def test_versioned_no_cache(api, auth1):
+
+
+    api.attach_authority('auth1', auth1)
+
+    with open('test_file1.txt', 'w+') as f:
+        f.write(u'this is another upload test')
+
+    assert os.path.isfile('test_file1.txt')
+
+    var2 = api.create('archive2', authority_name='auth1', versioned=True)
+    var2.update('test_file1.txt')
+
+    #make sure the version is captured
+    assert var2.get_version_path() == 'archive2/0.0.1'
+
+    var2.delete()
+    #confirm it has been deleted from the manager
+    with pytest.raises(KeyError):
+        api.get_archive('archive2')
+
+    #confirm that it is not present in the fs
+    with pytest.raises(ResourceNotFoundError):
+        api._authorities['auth1'].fs.open('archive2' 'r') 
+
+    assert api.listdir('', authority_name='auth1') == []
+
+@pytest.mark.remove_dir
+def test_remove_dir_multi_versions_remove(api, auth1):
+
+
+    cache = TempFS()
+    api.attach_authority('auth1', auth1)
+    api.attach_cache(cache)
+
+    with open('test_file.txt', 'w+') as f:
+        f.write(u'this is an upload test')
+
+    var = api.create('archive1', authority_name='auth1', versioned=True)
+    var.update('test_file.txt', cache=True)
+
+    with var.open('w') as f:
+        f.write(u'update update')
+
+
+    assert len(var.get_versions()) == 2
+
+    var.delete()
+
+    with pytest.raises(KeyError):
+        api.get_archive('archive1')
+
+    with pytest.raises(ResourceNotFoundError):
+        api._authorities['auth1'].fs.open('archive1', 'r')
+
+    with pytest.raises(ResourceNotFoundError):
+        api.cache.fs.open('archive1', 'r')
+
+    assert api.listdir('', authority_name='auth1') == []
+
+
+
+@pytest.mark.remove_dir
+def test_multi_api(api1, api2, auth1, cache1, cache2, opener):
+    '''
+    Test upload/download/cache operations with two users
+    '''
+    # Create two separate users. Each user connects to the
+    # same authority and the same manager table (apis are
+    # initialized with the same manager table but different
+    # manager instance objects). Each user has its own
+    # separate cache.
+
+    api1.attach_authority('auth1', auth1)
+    api1.attach_cache(cache1)
+
+    api2.attach_authority('auth1', auth1)
+    api2.attach_cache(cache2)
+
+    with open('text_file.txt', 'w') as f:
+        f.write(u'Stay Stoked')
+
+    archive1 = api1.create('myArchive', versioned=False)
+    archive1.update('text_file.txt')
+
+    # Turn on caching in archive 1 and assert creation
+
+    archive1.cache()
+    assert archive1.is_cached() is True
+    assert archive1.api.cache.fs is cache1
+
+    with opener(archive1, 'w+') as f1:
+        f1.write(u('Be happy and Stay Stoked'))
+
+    assert auth1.isfile('myArchive')
+    assert cache1.isfile('myArchive')
+
+    archive2 = api2.get_archive('myArchive')
+
+    # Turn on caching in archive 2 and assert creation
+    archive2.cache()
+    assert archive2.is_cached() is True
+    assert archive2.api.cache.fs is cache2
+
+    with archive2.open('r') as f:
+        assert u(f.read()) == u'Be happy and Stay Stoked'
+
+    archive2.delete()
+
+    with pytest.raises(ResourceNotFoundError):
+        api2._authorities['auth1'].fs.open('myArchive', 'r')
+
+    with pytest.raises(ResourceNotFoundError):
+        api2.cache.fs.open('myArchive', 'r')
+
+    assert cache1.isfile('myArchive')
+
+    with pytest.raises(ResourceNotFoundError):
+        api1._authorities['auth1'].fs.open('myArchive', 'r')
+
+    
+    archive1.remove_from_cache()
+
+    with pytest.raises(ResourceNotFoundError):
+        api1.cache.fs.open('myArchive', 'r')
+        
+     
+


### PR DESCRIPTION
 - [x] closes #212
 - [x] tests added / passed:  
 - [x] docs reflect changes
 - [x] passes ``flake8 datafs examples tests docs``
 - [x] whatsnew entry

Tests updated to remove old file artifacts in testing databases. New tests added under `tests/test_removemdir.py`

This pr is an implementation of the pyfilesystem `'fs.removedir` called via a new implementation of `archive.delete`. Previously, `archive.delete` removed the archive record from the manager as well as removing any version-name file objects from the file system. They did not, however, remove the top-level namespace. For example, previously, if you had an archive with name `tas/global` with version `0.0.1`, and `0.0.2` and you called

 `api.delete_archive('tas/global')`  it would delete file objects `tas/global/0.0.1` and `tas/global/0.02` from the file system. However, from the following, you can see that our archive still exists in file system name space. 

```
In [1]: api.listdir('tas/global') 
Out [1]: []

In [2]: api.listdir('tas')
Out [2] ['global']

```

PR Implementation of delete
---------------------------------

```
In [1]: api.listdir('tas/global')
Out [1]: [u'0.0.1', u'0.0.2']

In [2]: api.listdir('tas/regional')
Out [2]: [u'0.0.1', u'0.0.2']

In [3]: api.listdir('tas')
Out [3]: [u'regional', u'global', u'adm1', u'adm2']

In [3]: tasg = api.get_archive('tas/global')

In [4]: tasg.delete()

In [ 5]: api.get_archive('tas/global')
...

KeyError: 'Archive "tas/global" not found'

In [6]: api.listdir('tas')
Out [6]: [u'regional', u'adm1', u'adm2']

In [7]: api.delete_archive('tas/regional')

In [8]: api.listdir('tas')
Out [8]: [u'adm1', u'adm2']

In [9]: api.get_archive('tas/regional')
...

KeyError: 'Archive "tas/regional" not found'

```

