### PR TITLE
gotta catch 'em all!

### DIFF
--- a/examples/snippets/pythonapi_io.py
+++ b/examples/snippets/pythonapi_io.py
@@ -224,7 +224,7 @@ Teardown
     >>> times = pd.date_range('2000-01-01', '2001-12-31', name='time')
     >>> annual_cycle = np.sin(2 * np.pi * (times.dayofyear / 365.25 - 0.28))
     >>>
-    >>> base = 10 + 15 * annual_cycle.reshape(-1, 1)
+    >>> base = 10 + 15 * np.array(annual_cycle).reshape(-1, 1)
     >>> tmin_values = base + 3 * np.random.randn(annual_cycle.size, 3)
     >>> tmax_values = base + 10 + 3 * np.random.randn(annual_cycle.size, 3)
     >>>

--- a/tests/test_version_metadata.py
+++ b/tests/test_version_metadata.py
@@ -48,7 +48,7 @@ class TestVersionedMetadata(object):
         np.random.seed(123)
         times = pd.date_range('2000-01-01', '2001-12-31', name='time')
         annual_cycle = np.sin(2 * np.pi * (times.dayofyear / 365.25 - 0.28))
-        base = 10 + 15 * annual_cycle.reshape(-1, 1)
+        base = 10 + 15 * np.array(annual_cycle).reshape(-1, 1)
 
         tmin_values = base + 3 * np.random.randn(annual_cycle.size, 3)
         tmax_values = base + 3 * np.random.randn(annual_cycle.size, 3)


### PR DESCRIPTION
 - [x] closes #281 
 - [x] tests added / passed
 - [x] docs reflect changes
 - [x] passes ``flake8 datafs examples tests docs``
 - [x] whatsnew entry

same pandas>=0.20.0 fix as last time, just this time for *all* the examples, not just one 😞 