### PR TITLE
Docs req

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+-r requirements_test.txt
+-r requirements_conda.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
--r requirements.txt
--r requirements_test.txt
--r requirements_conda.txt
+-r ../requirements.txt
+-r ../requirements_test.txt
+-r ../requirements_conda.txt

--- a/docs/whatsnew/v0.8.0.txt
+++ b/docs/whatsnew/v0.8.0.txt
@@ -18,6 +18,7 @@ Under the hood
 ~~~~~~~~~~~~~~
 
   - Update ``ondisk`` example for pandas ``v0.20.0`` compatability (:issue:`281`)
-  - upgrade pip before build on travis (:issue:`283`)
+  - Upgrade pip before build on travis (:issue:`283`)
+  - Added a requirements file for the readthedocs build in ``docs/requirements.txt`` (:issue:`287`)
 
 See the issue tracker on GitHub for a complete list.


### PR DESCRIPTION
 - [x] closes #287 
 - [x] tests added / passed
 - [x] docs reflect changes
 - [x] passes ``flake8 datafs examples tests docs``
 - [x] whatsnew entry

Docs weren't building on rtd. They do build on this branch (added as a temporary protected build).