### PR TITLE
point boto-config to /dev/null

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 
 python:
   - 2.7
-  - pypy
+  - pypy-5.4.1
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ matrix:
       env: DATAFS_TEST_ENV=xarray
 
 install:
+  - export BOTO_CONFIG=/dev/null
   - pip install --upgrade pip
   - if [[ "$DATAFS_TEST_ENV" == "xarray" ]]; then
       if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
@@ -75,6 +76,7 @@ services:
 before_install:
   - docker pull tray/dynamodb-local
   - docker run -d -p 8000:8000 tray/dynamodb-local -inMemory -port 8000
+  - export BOTO_CONFIG=/dev/null
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
 
 matrix:
   exclude:
-    - python: pypy
+    - python: pypy-5.4.1
       env: DATAFS_TEST_ENV=xarray
 
 install:

--- a/examples/snippets/pythonapi_finding_archives.py
+++ b/examples/snippets/pythonapi_finding_archives.py
@@ -110,10 +110,21 @@ Displayed example 3 code
 
 .. code-block:: python
 
-    >>> api.listdir('impactlab')
-    [u'labor', u'climate', u'conflict', u'mortality']
+    >>> api.listdir('impactlab') # doctest: +SKIP
+    ['labor', 'climate', 'conflict', 'mortality']
 
 .. EXAMPLE-BLOCK-3-END
+
+And the actual test:
+
+.. code-block:: python
+
+    >>> (set(api.listdir('impactlab')) == set([
+    ...     'labor', 'climate', 'conflict', 'mortality']))
+    ...
+    True
+
+
 
 Example 4
 ---------

--- a/tests/cli_snippets/test_cli_finding_archives.py
+++ b/tests/cli_snippets/test_cli_finding_archives.py
@@ -9,11 +9,13 @@ def test_cli_listdir(cli_validator_listdir):
 
 Snippet 1
 
+This test can't currently be tested with clatter, due to unpredictable ordering
+
 .. EXAMPLE-BLOCK-1-START
 
 .. code-block:: bash
 
-    $ datafs listdir impactlab
+    $ datafs listdir impactlab # doctest: +SKIP
     labor
     climate
     conflict


### PR DESCRIPTION
 - [x] closes #319 
 - [x] tests added / passed
 - [x] docs reflect changes
 - [x] passes ``flake8 datafs examples tests docs``
 - [ ] whatsnew entry

point boto-config to /dev/null as per https://github.com/travis-ci/travis-ci/issues/7940

This is a small, emergency patch to get tests running again, although short of moving away from the trusty environment, this seems like the best solution.
